### PR TITLE
Additional scores added (can be used for prioritization).

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,24 +44,27 @@ Before using the tool, be sure all steps below are done (certain steps can be sk
 
 ### Usage
 
-`java -jar vibe-with-dependencies.jar [-h] [-v] -t <FILE> [-w <FILE> ( -c | -d ) -m <NUMBER>] -o <FILE> -p <HPO ID> [-p <HPO ID>]...`
+`java -jar vibe-with-dependencies.jar [-h] [-v] -t <FILE> [-w <FILE> -n <NAME> -m <NUMBER>] -o <FILE> [-s <NAME>] [-l] -p <HPO ID> [-p <HPO ID>]...`
 
 ### Examples
-Using only the user-defined phenotypes:
+Using only the user-defined phenotypes with the output being sorted based on the highest gene-disease association score
+present per gene:
 
-`java -jar vibe-with-dependencies.jar -t TDB/ -o results.tsv -p HP:0000123 -p HP:0001234 -p HP:0012345`
-
----
-
-Using the user-defined phenotypes and phenotypes that are related to them with a maximum distance of 2:
-
-`java -jar vibe-with-dependencies.jar -t TDB/ -w hp.owl -d -m 2 -o results.tsv -p HP:0000123 -p HP:0001234 -p HP:0012345`
+`java -jar vibe-with-dependencies.jar -v -t TDB/ -s gda_max -o results.tsv -p HP:0002996 -p HP:0001377`
 
 ---
 
-Using the user-defined phenotypes and their (grand)children with a maximum distance of 5:
+Using the user-defined phenotypes and phenotypes that are related to them with a maximum distance of 1 with the output
+ sorted based on the Disease Specificity Index:
 
-`java -jar vibe-with-dependencies.jar -t TDB/ -w hp.owl -c -m 5 -o results.tsv -p HP:0000123 -p HP:0001234 -p HP:0012345`
+`java -jar vibe-with-dependencies.jar -v -t TDB/ -w hp.owl -n distance -m 1 -s dsi -o results.tsv -p HP:0002996`
+
+---
+
+Using the user-defined phenotypes and their (grand)children with a maximum distance of 2 with the output sorted based on
+the Disease Pleiotropy Index:
+
+`java -jar vibe-with-dependencies.jar -v -t TDB/ -w hp.owl -n children -m 2 -s dpi -o results.tsv -p HP:0002996`
 
 
 [java_download]:https://www.java.com/download

--- a/README.md
+++ b/README.md
@@ -37,12 +37,32 @@ Before using the tool, be sure all steps below are done (certain steps can be sk
 ### Creating a local TDB dataset.
 
 1. [Download][jena_download] and [configure][jena_configure] the environment so that the Jena scripts can be used.
-2. Download the required files ([DisGeNET][disgenet_rdf_v5_dump], [SIO][sio_owl], [HPO][hpo_owl]).
+2. Download the required files ([DisGeNET][disgenet_rdf_v5_dump], [SIO][sio_owl]).
 3. Run `tdbloader2 --loc /path/to/store/TDB /path/to/disgenet/dump/*.ttl /path/to/sio-release.owl`
 
 ## Running the application
 
-`java -jar vibe-with-dependencies.jar [-h] [-v] -n <FILE> -nd <NUMBER> -d <DIR> -o <FILE> -p <HPO ID> [-p <HPO ID>]...` 
+### Usage
+
+`java -jar vibe-with-dependencies.jar [-h] [-v] -t <FILE> [-w <FILE> ( -c | -d ) -m <NUMBER>] -o <FILE> -p <HPO ID> [-p <HPO ID>]...`
+
+### Examples
+Using only the user-defined phenotypes:
+
+`java -jar vibe-with-dependencies.jar -t TDB/ -o results.tsv -p HP:0000123 -p HP:0001234 -p HP:0012345`
+
+---
+
+Using the user-defined phenotypes and phenotypes that are related to them with a maximum distance of 2:
+
+`java -jar vibe-with-dependencies.jar -t TDB/ -w hp.owl -d -m 2 -o results.tsv -p HP:0000123 -p HP:0001234 -p HP:0012345`
+
+---
+
+Using the user-defined phenotypes and their (grand)children with a maximum distance of 5:
+
+`java -jar vibe-with-dependencies.jar -t TDB/ -w hp.owl -c -m 5 -o results.tsv -p HP:0000123 -p HP:0001234 -p HP:0012345`
+
 
 [java_download]:https://www.java.com/download
 [maven_download]:https://maven.apache.org/download.cgi

--- a/TestNGPreprocessing.sh
+++ b/TestNGPreprocessing.sh
@@ -26,7 +26,7 @@ IMPORTANT:  Requires Apache Jena TDB Command-line Utilities to be configured.
 readonly SEP_SIDE='######## ######## ########'
 
 # Download location of resource files.
-readonly TEST_RESOURCES_DOWNLOAD_NAME="test_resources_2018-05-03.tar.gz"
+readonly TEST_RESOURCES_DOWNLOAD_NAME="test_resources_2018-07-13.tar.gz"
 readonly TEST_RESOURCES_DOWNLOAD="https://molgenis26.target.rug.nl/downloads/vibe/${TEST_RESOURCES_DOWNLOAD_NAME}"
 
 # Base path (to script).

--- a/src/main/java/org/molgenis/vibe/formats/BiologicalEntity.java
+++ b/src/main/java/org/molgenis/vibe/formats/BiologicalEntity.java
@@ -141,6 +141,12 @@ public abstract class BiologicalEntity implements ResourceUri, Comparable<Biolog
         }
     }
 
+    /**
+     * While uniqueness is based on the {@link #id} (as each {@link #id} should only occur once and data belonging to it
+     * should be consistent), {@link #toString()} can be used for testing whether data retrieval from external sources
+     * yielded the expected results.
+     * @return
+     */
     @Override
     public String toString() {
         return "BiologicalEntity{" +

--- a/src/main/java/org/molgenis/vibe/formats/BiologicalEntityCollection.java
+++ b/src/main/java/org/molgenis/vibe/formats/BiologicalEntityCollection.java
@@ -196,7 +196,7 @@ public abstract class BiologicalEntityCollection<T1 extends BiologicalEntity, T2
     @Override
     public String toString() {
         return "BiologicalEntityCollection{" +
-                "combinationsMap=" + combinationsMap +
+                "combinationsMap.keySet()=" + combinationsMap.keySet() +
                 '}';
     }
 

--- a/src/main/java/org/molgenis/vibe/formats/BiologicalEntityCombination.java
+++ b/src/main/java/org/molgenis/vibe/formats/BiologicalEntityCombination.java
@@ -33,6 +33,12 @@ public abstract class BiologicalEntityCombination<T1 extends BiologicalEntity, T
         this.t2 = requireNonNull(t2);
     }
 
+    /**
+     * While uniqueness is based on the 2 available {@link BiologicalEntity#id}s (as each combination should only occur
+     * once and data belonging to it should be consistent), {@link #toString()} can be used for testing whether data
+     * retrieval from external sources yielded the expected results.
+     * @return
+     */
     @Override
     public String toString() {
         return "BiologicalEntityCombination{" +

--- a/src/main/java/org/molgenis/vibe/formats/Disease.java
+++ b/src/main/java/org/molgenis/vibe/formats/Disease.java
@@ -40,4 +40,9 @@ public class Disease extends BiologicalEntity {
     public Disease(String id, String name, URI uri) throws InvalidStringFormatException {
         super(id, name, uri);
     }
+
+    @Override
+    public String toString() {
+        return "Disease{} " + super.toString();
+    }
 }

--- a/src/main/java/org/molgenis/vibe/formats/EnumTypeDefiner.java
+++ b/src/main/java/org/molgenis/vibe/formats/EnumTypeDefiner.java
@@ -4,22 +4,38 @@ public interface EnumTypeDefiner {
     String getId();
 
     /**
-     * Retrieves {@link Enum} type based on a given {@link String} (retrieved through {@link #getId()}. Ignores case
-     * for comparison.
+     * Retrieves {@link Enum} type based on a given {@link String} (using {@link #getId()} for comparison). Ignores case
+     * during comparison. Any {@code null} values (either as parameter or from the {@link Enum} types used for
+     * comparison) will be ignored.
      * @param id the name that is linked to a specific {@link Enum} type
-     * @param type the {@link Enum} class
-     * @return an {@link Enum} type from the {@link Class} {@code type} or {@code null} if no match was found
+     * @param type the {@link Enum} class for which the the type should be retrieved
+     * @return the {@link Enum} type that matched with {@code id}
+     * @throws EnumConstantNotPresentException if {@link Enum} type does not exist (no match was found) or the {@code id}
+     * is {@code null}
+     * @throws IllegalArgumentException if {@code type} is null
      */
-    static <T extends Enum&EnumTypeDefiner> T retrieve(String id, Class<T> type) {
-        // Goes through all enym types.
-        for(T constant : type.getEnumConstants()) {
-            // Checks if input name is equal to the enum type id field. If so, returns enum type.
-            if(id.toLowerCase().equals(constant.getId().toLowerCase())) {
-                return constant;
+    static <T extends Enum&EnumTypeDefiner> T retrieve(String id, Class<T> type) throws EnumConstantNotPresentException, IllegalArgumentException {
+        // Type should not be null as otherwise no comparison can be made.
+        if(type == null) {
+            throw new IllegalArgumentException("EnumTypeDefiner should not receive null as comparison Enum class.");
+        }
+
+        // Skips checking when an ID is null (if Enum constants are present with null ID, these will not match).
+        if(id != null) {
+            // Goes through all enym types.
+            for (T constant : type.getEnumConstants()) {
+                // Skips Enum types with id null.
+                if(constant.getId() == null) {
+                    continue;
+                }
+                // Checks if input name is equal to the enum type id field. If so, returns enum type.
+                if (id.toLowerCase().equals(constant.getId().toLowerCase())) {
+                    return constant;
+                }
             }
         }
 
-        // Throws an Exception if looking for an enum constant that does not exist.
+        // Throws an Exception if looking for an enum type that does not exist.
         throw new EnumConstantNotPresentException(type, id);
     }
 }

--- a/src/main/java/org/molgenis/vibe/formats/EnumTypeDefiner.java
+++ b/src/main/java/org/molgenis/vibe/formats/EnumTypeDefiner.java
@@ -4,7 +4,8 @@ public interface EnumTypeDefiner {
     String getId();
 
     /**
-     * Retrieves {@link Enum} type based on a given {@link String} (retrieved through {@link #getId()}
+     * Retrieves {@link Enum} type based on a given {@link String} (retrieved through {@link #getId()}. Ignores case
+     * for comparison.
      * @param id the name that is linked to a specific {@link Enum} type
      * @param type the {@link Enum} class
      * @return an {@link Enum} type from the {@link Class} {@code type} or {@code null} if no match was found
@@ -13,12 +14,12 @@ public interface EnumTypeDefiner {
         // Goes through all enym types.
         for(T constant : type.getEnumConstants()) {
             // Checks if input name is equal to the enum type id field. If so, returns enum type.
-            if(id.equals(constant.getId())) {
+            if(id.toLowerCase().equals(constant.getId().toLowerCase())) {
                 return constant;
             }
         }
 
-        // Return null if no match was found.
-        return null;
+        // Throws an Exception if looking for an enum constant that does not exist.
+        throw new EnumConstantNotPresentException(type, id);
     }
 }

--- a/src/main/java/org/molgenis/vibe/formats/Gene.java
+++ b/src/main/java/org/molgenis/vibe/formats/Gene.java
@@ -88,7 +88,6 @@ public class Gene extends BiologicalEntity {
 
     /**
      * {@inheritDoc}
-     * @return
      */
     @Override
     public String toString() {

--- a/src/main/java/org/molgenis/vibe/formats/Gene.java
+++ b/src/main/java/org/molgenis/vibe/formats/Gene.java
@@ -21,8 +21,28 @@ public class Gene extends BiologicalEntity {
      */
     private String symbol;
 
+    /**
+     * The Disease Specificity Index (DSI) as stored within DisGeNET for a gene.
+     * @see <a href="http://www.disgenet.org/web/DisGeNET/menu/dbinfo#specificity">http://www.disgenet.org/web/DisGeNET/menu/dbinfo#specificity</a>
+     */
+    private Double diseaseSpecificityIndex;
+
+    /**
+     * The Disease Pleiotropy Index (DPI) as stored within DisGeNET for a gene.
+     * @see <a href="http://www.disgenet.org/web/DisGeNET/menu/dbinfo#pleiotropy">http://www.disgenet.org/web/DisGeNET/menu/dbinfo#pleiotropy</a>
+     */
+    private Double diseasePleiotropyIndex;
+
     public String getSymbol() {
         return symbol;
+    }
+
+    public Double getDiseaseSpecificityIndex() {
+        return diseaseSpecificityIndex;
+    }
+
+    public Double getDiseasePleiotropyIndex() {
+        return diseasePleiotropyIndex;
     }
 
     @Override
@@ -49,15 +69,33 @@ public class Gene extends BiologicalEntity {
         super(id);
     }
 
-    public Gene(String id, String name, String symbol, URI uri) throws InvalidStringFormatException {
+    /**
+     *
+     * @param id unique NCBI gene ID
+     * @param name {@link BiologicalEntity#name}
+     * @param symbol HUGO Gene Nomenclature Committee (HGNC) name
+     * @param dsi diseaseSpecificityIndex
+     * @param dpi diseasePleiotropyIndex
+     * @param uri {@link BiologicalEntity#uri}
+     * @throws InvalidStringFormatException
+     */
+    public Gene(String id, String name, String symbol, Double dsi, Double dpi, URI uri) throws InvalidStringFormatException {
         super(id, name, uri);
         this.symbol = requireNonNull(symbol);
+        this.diseaseSpecificityIndex = requireNonNull(dsi);
+        this.diseasePleiotropyIndex = requireNonNull(dpi);
     }
 
+    /**
+     * {@inheritDoc}
+     * @return
+     */
     @Override
     public String toString() {
         return "Gene{" +
                 "symbol='" + symbol + '\'' +
+                ", diseaseSpecificityIndex=" + diseaseSpecificityIndex +
+                ", diseasePleiotropyIndex=" + diseasePleiotropyIndex +
                 "} " + super.toString();
     }
 }

--- a/src/main/java/org/molgenis/vibe/formats/Gene.java
+++ b/src/main/java/org/molgenis/vibe/formats/Gene.java
@@ -23,12 +23,16 @@ public class Gene extends BiologicalEntity {
 
     /**
      * The Disease Specificity Index (DSI) as stored within DisGeNET for a gene.
+     * A higher score indicates a higher specificity (less associated diseases).
+     * A 0 indicates only associations with phenotypes.
      * @see <a href="http://www.disgenet.org/web/DisGeNET/menu/dbinfo#specificity">http://www.disgenet.org/web/DisGeNET/menu/dbinfo#specificity</a>
      */
     private Double diseaseSpecificityIndex;
 
     /**
      * The Disease Pleiotropy Index (DPI) as stored within DisGeNET for a gene.
+     * A higher score indicates more disease (MeSH) classes being associated.
+     * A 0 indicates either only associations with phenotypes or the associated diseases do not have a MeSH class.
      * @see <a href="http://www.disgenet.org/web/DisGeNET/menu/dbinfo#pleiotropy">http://www.disgenet.org/web/DisGeNET/menu/dbinfo#pleiotropy</a>
      */
     private Double diseasePleiotropyIndex;

--- a/src/main/java/org/molgenis/vibe/formats/Phenotype.java
+++ b/src/main/java/org/molgenis/vibe/formats/Phenotype.java
@@ -44,4 +44,9 @@ public class Phenotype extends BiologicalEntity {
     public Phenotype(String id, String name, URI uri) throws InvalidStringFormatException {
         super(id, name, uri);
     }
+
+    @Override
+    public String toString() {
+        return "Phenotype{} " + super.toString();
+    }
 }

--- a/src/main/java/org/molgenis/vibe/io/output/ResultsPerGeneSeparatedValuesFileOutputWriter.java
+++ b/src/main/java/org/molgenis/vibe/io/output/ResultsPerGeneSeparatedValuesFileOutputWriter.java
@@ -81,7 +81,8 @@ public class ResultsPerGeneSeparatedValuesFileOutputWriter extends SeparatedValu
         BufferedWriter writer = getWriter();
 
         // Writes header.
-        writer.write("gene" + getSeparator() + "disease pubmed IDs" + getSeparator() + "highest score");
+        writer.write("gene" + getSeparator() + "diseases" + getSeparator() + "highest GDA score" +
+                getSeparator() + "DSI" + getSeparator() + "DPI");
         writer.newLine();
 
         // Goes through all ordered genes.
@@ -111,17 +112,18 @@ public class ResultsPerGeneSeparatedValuesFileOutputWriter extends SeparatedValu
                 }
 
                 // Writes the disease name surrouned by quotes.
-                writer.write(QUOTE_MARK + gdc.getDisease().getName() + QUOTE_MARK);
+                writer.write(gdc.getDisease().getName());
 
-                // If there is evidence, writes these as well.
-                if(gdc.getAllEvidence().size() > 0) {
-                    // Merges the evidence URIs with as separator the values separator.
-                    String evidence = StringUtils.join(gdc.getAllEvidence(), valuesSeparator.toString());
-                    writer.write(keyValueSeparator + evidence);
-                }
+//                // If there is evidence, writes these as well.
+//                if(gdc.getAllEvidence().size() > 0) {
+//                    // Merges the evidence URIs with as separator the values separator.
+//                    String evidence = StringUtils.join(gdc.getAllEvidence(), valuesSeparator.toString());
+//                    writer.write(keyValueSeparator + evidence);
+//                }
             }
 
-            writer.write(getSeparator() + Double.toString(highestScore));
+            writer.write(getSeparator() + Double.toString(highestScore) + getSeparator() +
+                    gene.getDiseaseSpecificityIndex() + getSeparator() + gene.getDiseasePleiotropyIndex());
             writer.newLine();
         }
 

--- a/src/main/java/org/molgenis/vibe/io/output/ValuesSeparator.java
+++ b/src/main/java/org/molgenis/vibe/io/output/ValuesSeparator.java
@@ -9,7 +9,8 @@ public enum ValuesSeparator {
     COLON(":"),
     SEMICOLON(";"),
     HYPHEN_MINUS("-"),
-    VERTICAL_LINE("|");
+    VERTICAL_LINE("|"),
+    EQUALS("=");
 
     /**
      * The separator character.

--- a/src/main/java/org/molgenis/vibe/ontology_processing/PhenotypesRetrieverFactory.java
+++ b/src/main/java/org/molgenis/vibe/ontology_processing/PhenotypesRetrieverFactory.java
@@ -20,7 +20,7 @@ public enum PhenotypesRetrieverFactory implements EnumTypeDefiner {
         }
     };
 
-    protected String id;
+    private String id;
 
     private String description;
 

--- a/src/main/java/org/molgenis/vibe/options_digestion/DisgenetRdfVersion.java
+++ b/src/main/java/org/molgenis/vibe/options_digestion/DisgenetRdfVersion.java
@@ -12,8 +12,7 @@ import java.util.regex.Pattern;
  * themselves.
  */
 public enum DisgenetRdfVersion implements EnumTypeDefiner {
-    V5("5"),
-    UNSUPPORTED(null);
+    V5("5");
 
     private String id;
 
@@ -27,22 +26,18 @@ public enum DisgenetRdfVersion implements EnumTypeDefiner {
     }
 
     /**
-     * Retrieves the {@link DisgenetRdfVersion} based on a {@link String}. If version is not supported, returns
-     * {@link DisgenetRdfVersion#UNSUPPORTED}. However, if {@code versionNumber} does not even adhere to the expected
+     * Retrieves the {@link DisgenetRdfVersion} based on a {@link String}. If version is not supported, throws an
+     * {@link EnumConstantNotPresentException}. However, if {@code versionNumber} does not even adhere to the expected
      * version number format, an {@link InvalidStringFormatException} is thrown instead.
      * @param versionNumber {@link String} from which the version number should be retrieved
      * @return an {@link DisgenetRdfVersion} enum of the specific version
      * @throws InvalidStringFormatException if {@code versionNumber} does not adhere to the regex "^[v|V]?([0-9]+).*$"
+     * @throws EnumConstantNotPresentException if the RDF version is not supported
      */
-    public static DisgenetRdfVersion retrieve(String versionNumber) throws InvalidStringFormatException {
+    public static DisgenetRdfVersion retrieve(String versionNumber) throws InvalidStringFormatException, EnumConstantNotPresentException {
         Matcher m = Pattern.compile("^[v|V]?([0-9]+).*$").matcher(versionNumber);
         if(m.matches()) {
-            DisgenetRdfVersion version = EnumTypeDefiner.retrieve(m.group(1), DisgenetRdfVersion.class);
-            // If no result is found, returns UNSUPPORTED (so that output is never null).
-            if(version == null) {
-                return DisgenetRdfVersion.UNSUPPORTED;
-            }
-            return version;
+            return EnumTypeDefiner.retrieve(m.group(1), DisgenetRdfVersion.class);
         } else {
             throw new InvalidStringFormatException(versionNumber + " does not adhere the required format: ^[v|V]?([0-9]+).*$");
         }

--- a/src/main/java/org/molgenis/vibe/options_digestion/RunMode.java
+++ b/src/main/java/org/molgenis/vibe/options_digestion/RunMode.java
@@ -9,7 +9,6 @@ import org.molgenis.vibe.io.ModelReader;
 import org.molgenis.vibe.io.TripleStoreDbReader;
 import org.molgenis.vibe.ontology_processing.PhenotypesRetriever;
 import org.molgenis.vibe.query_output_digestion.prioritization.GenePrioritizer;
-import org.molgenis.vibe.query_output_digestion.prioritization.HighestSingleDisgenetScoreGenePrioritizer;
 import org.molgenis.vibe.query_output_digestion.prioritization.Prioritizer;
 import org.molgenis.vibe.rdf_processing.GenesForPhenotypeRetriever;
 
@@ -86,7 +85,7 @@ public enum RunMode {
 
     protected Prioritizer orderGenes(GeneDiseaseCollection geneDiseaseCollection) {
         getAppOptions().printVerbose("# Ordering genes based on priority.");
-        GenePrioritizer prioritizer = new HighestSingleDisgenetScoreGenePrioritizer(geneDiseaseCollection);
+        GenePrioritizer prioritizer = getAppOptions().getGenePrioritizerFactory().create(geneDiseaseCollection);
         prioritizer.run();
         printElapsedTime();
 

--- a/src/main/java/org/molgenis/vibe/query_output_digestion/prioritization/DiseasePleiotropyIndexGenePrioritizer.java
+++ b/src/main/java/org/molgenis/vibe/query_output_digestion/prioritization/DiseasePleiotropyIndexGenePrioritizer.java
@@ -1,0 +1,23 @@
+package org.molgenis.vibe.query_output_digestion.prioritization;
+
+import org.molgenis.vibe.formats.Gene;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+
+public class DiseasePleiotropyIndexGenePrioritizer extends GenePrioritizer {
+    public DiseasePleiotropyIndexGenePrioritizer(List<Gene> data) {
+        super(data);
+    }
+
+    public DiseasePleiotropyIndexGenePrioritizer(Set<Gene> data) {
+        super(data);
+    }
+
+    @Override
+    public void run() {
+        // Sorts the genes with lowest disease pleiotropy index first.
+        getPriority().sort(Comparator.comparingDouble(Gene::getDiseasePleiotropyIndex));
+    }
+}

--- a/src/main/java/org/molgenis/vibe/query_output_digestion/prioritization/DiseaseSpecificityIndexGenePrioritizer.java
+++ b/src/main/java/org/molgenis/vibe/query_output_digestion/prioritization/DiseaseSpecificityIndexGenePrioritizer.java
@@ -1,0 +1,23 @@
+package org.molgenis.vibe.query_output_digestion.prioritization;
+
+import org.molgenis.vibe.formats.Gene;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+
+public class DiseaseSpecificityIndexGenePrioritizer extends GenePrioritizer {
+    public DiseaseSpecificityIndexGenePrioritizer(List<Gene> data) {
+        super(data);
+    }
+
+    public DiseaseSpecificityIndexGenePrioritizer(Set<Gene> data) {
+        super(data);
+    }
+
+    @Override
+    public void run() {
+        // Sorts the genes with highest disease specificity index first.
+        getPriority().sort(Comparator.comparingDouble(Gene::getDiseaseSpecificityIndex).reversed());
+    }
+}

--- a/src/main/java/org/molgenis/vibe/query_output_digestion/prioritization/GenePrioritizerFactory.java
+++ b/src/main/java/org/molgenis/vibe/query_output_digestion/prioritization/GenePrioritizerFactory.java
@@ -6,19 +6,19 @@ import org.molgenis.vibe.formats.GeneDiseaseCollection;
 public enum GenePrioritizerFactory implements EnumTypeDefiner{
     HIGHEST_DISGENET_SCORE("gda_max") {
         @Override
-        public GenePrioritizer sort(GeneDiseaseCollection geneDiseaseCollection) {
+        public GenePrioritizer create(GeneDiseaseCollection geneDiseaseCollection) {
              return new HighestSingleDisgenetScoreGenePrioritizer(geneDiseaseCollection);
         }
     },
     DISEASE_SPECIFICITY_INDEX("dsi") {
         @Override
-        public GenePrioritizer sort(GeneDiseaseCollection geneDiseaseCollection) {
+        public GenePrioritizer create(GeneDiseaseCollection geneDiseaseCollection) {
             return new DiseaseSpecificityIndexGenePrioritizer(geneDiseaseCollection.getGenes());
         }
     },
     DISEASE_PLEIOTROPY_INDEX("dpi") {
         @Override
-        public GenePrioritizer sort(GeneDiseaseCollection geneDiseaseCollection) {
+        public GenePrioritizer create(GeneDiseaseCollection geneDiseaseCollection) {
             return new DiseasePleiotropyIndexGenePrioritizer(geneDiseaseCollection.getGenes());
         }
     };
@@ -34,7 +34,7 @@ public enum GenePrioritizerFactory implements EnumTypeDefiner{
         this.id = id;
     }
 
-    public abstract GenePrioritizer sort(GeneDiseaseCollection geneDiseaseCollection);
+    public abstract GenePrioritizer create(GeneDiseaseCollection geneDiseaseCollection);
 
     public static GenePrioritizerFactory retrieve(String name) {
         return EnumTypeDefiner.retrieve(name, GenePrioritizerFactory.class);

--- a/src/main/java/org/molgenis/vibe/query_output_digestion/prioritization/GenePrioritizerFactory.java
+++ b/src/main/java/org/molgenis/vibe/query_output_digestion/prioritization/GenePrioritizerFactory.java
@@ -1,0 +1,42 @@
+package org.molgenis.vibe.query_output_digestion.prioritization;
+
+import org.molgenis.vibe.formats.EnumTypeDefiner;
+import org.molgenis.vibe.formats.GeneDiseaseCollection;
+
+public enum GenePrioritizerFactory implements EnumTypeDefiner{
+    HIGHEST_DISGENET_SCORE("gda_max") {
+        @Override
+        public GenePrioritizer sort(GeneDiseaseCollection geneDiseaseCollection) {
+             return new HighestSingleDisgenetScoreGenePrioritizer(geneDiseaseCollection);
+        }
+    },
+    DISEASE_SPECIFICITY_INDEX("dsi") {
+        @Override
+        public GenePrioritizer sort(GeneDiseaseCollection geneDiseaseCollection) {
+            return new DiseaseSpecificityIndexGenePrioritizer(geneDiseaseCollection.getGenes());
+        }
+    },
+    DISEASE_PLEIOTROPY_INDEX("dpi") {
+        @Override
+        public GenePrioritizer sort(GeneDiseaseCollection geneDiseaseCollection) {
+            return new DiseasePleiotropyIndexGenePrioritizer(geneDiseaseCollection.getGenes());
+        }
+    };
+
+    private String id;
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    GenePrioritizerFactory(String id) {
+        this.id = id;
+    }
+
+    public abstract GenePrioritizer sort(GeneDiseaseCollection geneDiseaseCollection);
+
+    public static GenePrioritizerFactory retrieve(String name) {
+        return EnumTypeDefiner.retrieve(name, GenePrioritizerFactory.class);
+    }
+}

--- a/src/main/java/org/molgenis/vibe/rdf_processing/GenesForPhenotypeRetriever.java
+++ b/src/main/java/org/molgenis/vibe/rdf_processing/GenesForPhenotypeRetriever.java
@@ -67,8 +67,10 @@ public class GenesForPhenotypeRetriever extends DisgenetRdfDataRetriever {
             String geneId = result.get("geneId").asLiteral().getString();
             String geneTitle= result.get("geneTitle").asLiteral().getString();
             String geneSymbol = result.get("geneSymbolTitle").asLiteral().getString();
+            double diseaseSpecificityIndex = result.get("dsiValue").asLiteral().getDouble();
+            double diseasePleiotropyIndex = result.get("dpiValue").asLiteral().getDouble();
 
-            Gene gene = new Gene(geneId, geneTitle, geneSymbol, geneUri);
+            Gene gene = new Gene(geneId, geneTitle, geneSymbol, diseaseSpecificityIndex, diseasePleiotropyIndex, geneUri);
             genes.add(gene);
             genesByUri.put(geneUri, gene);
         }
@@ -100,7 +102,7 @@ public class GenesForPhenotypeRetriever extends DisgenetRdfDataRetriever {
             Gene gene = genesByUri.get(geneUri);
 
             // Retrieves score belonging to the gene-disease combination.
-            double score = Double.parseDouble(result.get("gdaScoreNumber").asLiteral().getString());
+            double score = result.get("gdaScoreNumber").asLiteral().getDouble();
 
             // The gene-disease combination belonging to the single query result.
             GeneDiseaseCombination comparisonGdc = new GeneDiseaseCombination(gene, disease, score);

--- a/src/main/java/org/molgenis/vibe/rdf_processing/query_string_creation/DisgenetQueryStringGenerator.java
+++ b/src/main/java/org/molgenis/vibe/rdf_processing/query_string_creation/DisgenetQueryStringGenerator.java
@@ -61,7 +61,7 @@ public final class DisgenetQueryStringGenerator extends QueryStringGenerator {
      * <br />between [0] and [1]: the HPO terms (URIs) to filter on (see {@link #createValuesStringForUris(Set)}
      * <br />between [1] and [2]: the gene-disease association type (see {@link DisgenetAssociationType})
      */
-    private static final String[] GENES_FOR_PHENOTYPES = {"SELECT DISTINCT ?gene ?geneId ?geneTitle ?geneSymbolTitle \n" +
+    private static final String[] GENES_FOR_PHENOTYPES = {"SELECT DISTINCT ?gene ?geneId ?geneTitle ?geneSymbolTitle ?dsiValue ?dpiValue \n" +
             "WHERE { \n" +
             "VALUES ?hpo ", " \n" + // [0] -> [1]
             "?hpo rdf:type sio:SIO_010056 . \n" +
@@ -80,9 +80,14 @@ public final class DisgenetQueryStringGenerator extends QueryStringGenerator {
             "?gene rdf:type ncit:C16612 ; \n" +
             "dcterms:identifier ?geneId ; \n" +
             "dcterms:title ?geneTitle ; \n" +
-            "sio:SIO_000205 ?geneSymbol . \n" +
+            "sio:SIO_000205 ?geneSymbol ; \n" +
+            "sio:SIO_000216 ?dsi, ?dpi . \n" +
             "?geneSymbol rdf:type ncit:C43568 ; \n" +
             "dcterms:title ?geneSymbolTitle . \n" +
+            "?dsi rdf:type sio:SIO_001351 ; \n" +
+            "sio:SIO_000300 ?dsiValue . \n" +
+            "?dpi rdf:type sio:SIO_001352 ; \n" +
+            "sio:SIO_000300 ?dpiValue . \n" +
             "}"
     };
 

--- a/src/test/java/org/molgenis/vibe/formats/EnumDefinerTester.java
+++ b/src/test/java/org/molgenis/vibe/formats/EnumDefinerTester.java
@@ -14,4 +14,9 @@ public class EnumDefinerTester {
     public void phenotypesRetrieverFactoryDistance() {
         Assert.assertEquals(EnumTypeDefiner.retrieve("distance", PhenotypesRetrieverFactory.class), PhenotypesRetrieverFactory.DISTANCE);
     }
+
+    @Test(expectedExceptions = EnumConstantNotPresentException.class)
+    public void phenotypesRetrieverFactoryNonExistent() {
+        EnumTypeDefiner.retrieve("iDoNotExist", PhenotypesRetrieverFactory.class);
+    }
 }

--- a/src/test/java/org/molgenis/vibe/formats/EnumDefinerTester.java
+++ b/src/test/java/org/molgenis/vibe/formats/EnumDefinerTester.java
@@ -19,4 +19,19 @@ public class EnumDefinerTester {
     public void phenotypesRetrieverFactoryNonExistent() {
         EnumTypeDefiner.retrieve("iDoNotExist", PhenotypesRetrieverFactory.class);
     }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void enumDefinerDoubleNullId() {
+        EnumTypeDefiner.retrieve(null, null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void enumDefinerNullClass() {
+        EnumTypeDefiner.retrieve("distance", null);
+    }
+
+    @Test(expectedExceptions = EnumConstantNotPresentException.class)
+    public void enumDefinerDoubleNull() {
+        EnumTypeDefiner.retrieve(null, PhenotypesRetrieverFactory.class);
+    }
 }

--- a/src/test/java/org/molgenis/vibe/options_digestion/CommandLineOptionsParserTester.java
+++ b/src/test/java/org/molgenis/vibe/options_digestion/CommandLineOptionsParserTester.java
@@ -18,10 +18,9 @@ public class CommandLineOptionsParserTester {
     private final String[] INVALID_ONTOLOGY_FILE = new String[]{"-w", TestData.NON_EXISTING.getFiles()[0]};
     private final String[] INVALID_ONTOLOGY_DIR = new String[]{"-w", TestData.NON_EXISTING.getDir()};
 
-
-    private final String[] HPO_ALGORITHM_1 = new String[]{"-c"};
-    private final String[] HPO_ALGORITHM_2 = new String[]{"-d"};
-    private final String[] BOTH_HPO_ALGORITHMS = new String[]{"-c", "-d"};
+    private final String[] HPO_ALGORITHM_1 = new String[]{"-n", "children"};
+    private final String[] HPO_ALGORITHM_2 = new String[]{"-n", "distance"};
+    private final String[] HPO_ALGORITHM_INVALID = new String[]{"-n", "myCustomName"};
 
     private final String[] MAX_DISTANCE = new String[]{"-m", "3"};
 
@@ -30,6 +29,10 @@ public class CommandLineOptionsParserTester {
 
     private final String[] NON_EXISTING_OUTPUT_FILE = new String[]{"-o", TestData.NON_EXISTING.getFiles()[0]};
 
+    private final String[] GENE_SORTING_1 = new String[]{"-s", "gda_max"};
+    private final String[] GENE_SORTING_2 = new String[]{"-s", "dsi"};
+    private final String[] GENE_SORTING_3 = new String[]{"-s", "dpi"};
+    private final String[] GENE_SORTING_INVALID = new String[]{"-s", "myCustomName"};
 
     @Test
     public void noArguments() throws IOException, ParseException {
@@ -42,8 +45,7 @@ public class CommandLineOptionsParserTester {
     @Test(expectedExceptions = UnrecognizedOptionException.class)
     public void unknownArgument() throws IOException, ParseException {
         String[] args = new String[]{"--zyxi"};
-        printError(args);
-        new CommandLineOptionsParser(args);
+        testWithErrorPrint(args);
     }
 
     @Test
@@ -60,114 +62,129 @@ public class CommandLineOptionsParserTester {
     }
 
     @Test
-    public void validSingleHpo() throws IOException, ParseException {
+    public void validSingleHpoWithHpoAlgorithm1() throws IOException, ParseException {
         String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, HPO_ALGORITHM_1, MAX_DISTANCE, SINGLE_HPO, NON_EXISTING_OUTPUT_FILE);
-        new CommandLineOptionsParser(args);
+        testWithErrorPrint(args);
+    }
+
+    @Test
+    public void validSingleHpoWithHpoAlgorithm2() throws IOException, ParseException {
+        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, HPO_ALGORITHM_2, MAX_DISTANCE, SINGLE_HPO, NON_EXISTING_OUTPUT_FILE);
+        testWithErrorPrint(args);
+    }
+
+    @Test(expectedExceptions = IOException.class)
+    public void validSingleHpoWithInvalidHpoAlgorithm() throws IOException, ParseException {
+        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, HPO_ALGORITHM_INVALID, MAX_DISTANCE, SINGLE_HPO, NON_EXISTING_OUTPUT_FILE);
+        testWithErrorPrint(args);
+    }
+
+    @Test
+    public void validSingleHpoWithSortAlgorithm1() throws IOException, ParseException {
+        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, HPO_ALGORITHM_1, MAX_DISTANCE, GENE_SORTING_1, SINGLE_HPO, NON_EXISTING_OUTPUT_FILE);
+        testWithErrorPrint(args);
+    }
+
+    @Test
+    public void validSingleHpoWithSortAlgorithm2() throws IOException, ParseException {
+        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, HPO_ALGORITHM_1, MAX_DISTANCE, GENE_SORTING_2, SINGLE_HPO, NON_EXISTING_OUTPUT_FILE);
+        testWithErrorPrint(args);
+    }
+
+    @Test
+    public void validSingleHpoWithSortAlgorithm3() throws IOException, ParseException {
+        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, HPO_ALGORITHM_1, MAX_DISTANCE, GENE_SORTING_3, SINGLE_HPO, NON_EXISTING_OUTPUT_FILE);
+        testWithErrorPrint(args);
+    }
+
+    @Test(expectedExceptions = IOException.class)
+    public void validSingleHpoWithInvalidSortAlgorithm() throws IOException, ParseException {
+        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, HPO_ALGORITHM_1, MAX_DISTANCE, GENE_SORTING_INVALID, SINGLE_HPO, NON_EXISTING_OUTPUT_FILE);
+        testWithErrorPrint(args);
     }
 
     @Test
     public void validSingleHpoWithoutOntology() throws IOException, ParseException {
         String[] args = stringArraysMerger(VALID_TDB, SINGLE_HPO, NON_EXISTING_OUTPUT_FILE);
-        new CommandLineOptionsParser(args);
+        testWithErrorPrint(args);
     }
 
     @Test
     public void validTwoHpos() throws IOException, ParseException {
         String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, HPO_ALGORITHM_1, MAX_DISTANCE, TWO_HPOS, NON_EXISTING_OUTPUT_FILE);
-        new CommandLineOptionsParser(args);
-    }
-
-    @Test(expectedExceptions = IOException.class)
-    public void missingAllButOneArgument() throws IOException, ParseException {
-        String[] args = HPO_ALGORITHM_1;
-        printError(args);
-        new CommandLineOptionsParser(args);
+        testWithErrorPrint(args);
     }
 
     @Test(expectedExceptions = IOException.class)
     public void missingTdb() throws IOException, ParseException {
         String[] args = stringArraysMerger(VALID_ONTOLOGY, HPO_ALGORITHM_1, MAX_DISTANCE, SINGLE_HPO, NON_EXISTING_OUTPUT_FILE);
-        printError(args);
-        new CommandLineOptionsParser(args);
+        testWithErrorPrint(args);
     }
 
     @Test(expectedExceptions = IOException.class)
-    public void missingOntologyWithAlgorithm() throws IOException, ParseException {
+    public void noOntologyWithHpoAlgorithm() throws IOException, ParseException {
         String[] args = stringArraysMerger(VALID_TDB, HPO_ALGORITHM_1, SINGLE_HPO, NON_EXISTING_OUTPUT_FILE);
-        printError(args);
-        new CommandLineOptionsParser(args);
+        testWithErrorPrint(args);
     }
 
     @Test(expectedExceptions = IOException.class)
-    public void missingOntologyWithMaxDistance() throws IOException, ParseException {
+    public void noOntologyWithHpoMaxDistance() throws IOException, ParseException {
         String[] args = stringArraysMerger(VALID_TDB, MAX_DISTANCE, SINGLE_HPO, NON_EXISTING_OUTPUT_FILE);
-        printError(args);
-        new CommandLineOptionsParser(args);
+        testWithErrorPrint(args);
     }
 
     @Test(expectedExceptions = IOException.class)
-    public void missingRelatedHpoAlgorithm() throws IOException, ParseException {
+    public void withOntologyMissingHpoAlgorithm() throws IOException, ParseException {
         String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, MAX_DISTANCE, SINGLE_HPO, NON_EXISTING_OUTPUT_FILE);
-        printError(args);
-        new CommandLineOptionsParser(args);
+        testWithErrorPrint(args);
     }
 
     @Test(expectedExceptions = IOException.class)
-    public void missingMaxDistanceRelatedHpo() throws IOException, ParseException {
+    public void withOntologyMissingHpoMaxDistance() throws IOException, ParseException {
         String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, HPO_ALGORITHM_1, SINGLE_HPO, NON_EXISTING_OUTPUT_FILE);
-        printError(args);
-        new CommandLineOptionsParser(args);
+        testWithErrorPrint(args);
+    }
+
+    @Test(expectedExceptions = IOException.class)
+    public void withOntologyMissingHpoAlgorithmAndHpoMaxDistance() throws IOException, ParseException {
+        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, SINGLE_HPO, NON_EXISTING_OUTPUT_FILE);
+        testWithErrorPrint(args);
     }
 
     @Test(expectedExceptions = IOException.class)
     public void missingPhenotype() throws IOException, ParseException {
         String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, HPO_ALGORITHM_1, MAX_DISTANCE, NON_EXISTING_OUTPUT_FILE);
-        printError(args);
-        new CommandLineOptionsParser(args);
+        testWithErrorPrint(args);
     }
 
     @Test(expectedExceptions = IOException.class)
     public void missingOutputFile() throws IOException, ParseException {
         String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, HPO_ALGORITHM_1, MAX_DISTANCE, SINGLE_HPO);
-        printError(args);
-        new CommandLineOptionsParser(args);
-    }
-
-    @Test(expectedExceptions = IOException.class)
-    public void hasBothExclusiveArguments() throws IOException, ParseException {
-        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, BOTH_HPO_ALGORITHMS, MAX_DISTANCE, SINGLE_HPO, NON_EXISTING_OUTPUT_FILE);
-        printError(args);
-        new CommandLineOptionsParser(args);
+        testWithErrorPrint(args);
     }
 
     @Test(expectedExceptions = IOException.class)
     public void invalidTdbDir() throws IOException, ParseException {
-        System.out.println(TestData.NON_EXISTING.getDir());
-        System.out.println(TestData.NON_EXISTING.getFiles()[0]);
         String[] args = stringArraysMerger(INVALID_TDB_DIR, VALID_ONTOLOGY, HPO_ALGORITHM_1, MAX_DISTANCE, SINGLE_HPO, NON_EXISTING_OUTPUT_FILE);
-        printError(args);
-        new CommandLineOptionsParser(args);
+        testWithErrorPrint(args);
     }
 
     @Test(expectedExceptions = IOException.class)
     public void invalidTdbFile() throws IOException, ParseException {
         String[] args = stringArraysMerger(INVALID_TDB_FILE, VALID_ONTOLOGY, HPO_ALGORITHM_1, MAX_DISTANCE, SINGLE_HPO, NON_EXISTING_OUTPUT_FILE);
-        printError(args);
-        new CommandLineOptionsParser(args);
+        testWithErrorPrint(args);
     }
 
     @Test(expectedExceptions = IOException.class)
     public void invalidOntologyFile() throws IOException, ParseException {
         String[] args = stringArraysMerger(VALID_TDB, INVALID_ONTOLOGY_FILE, HPO_ALGORITHM_1, MAX_DISTANCE, SINGLE_HPO, NON_EXISTING_OUTPUT_FILE);
-        printError(args);
-        new CommandLineOptionsParser(args);
+        testWithErrorPrint(args);
     }
 
     @Test(expectedExceptions = IOException.class)
     public void invalidOntologyDir() throws IOException, ParseException {
         String[] args = stringArraysMerger(VALID_TDB, INVALID_ONTOLOGY_DIR, HPO_ALGORITHM_1, MAX_DISTANCE, SINGLE_HPO, NON_EXISTING_OUTPUT_FILE);
-        printError(args);
-        new CommandLineOptionsParser(args);
+        testWithErrorPrint(args);
     }
 
     private String[] stringArraysMerger(String[]... arrays) {
@@ -178,7 +195,7 @@ public class CommandLineOptionsParserTester {
         return fullArray;
     }
 
-    private void printError(String[] args) throws IOException, ParseException {
+    private void testWithErrorPrint(String[] args) throws IOException, ParseException {
         try {
             new CommandLineOptionsParser(args);
         } catch(Exception e) {

--- a/src/test/java/org/molgenis/vibe/options_digestion/DisgenetRdfVersionTester.java
+++ b/src/test/java/org/molgenis/vibe/options_digestion/DisgenetRdfVersionTester.java
@@ -6,7 +6,6 @@ import org.testng.annotations.Test;
 
 public class DisgenetRdfVersionTester {
     private static final DisgenetRdfVersion rdfV5 = DisgenetRdfVersion.V5;
-    private static final DisgenetRdfVersion rdfUnsupported = DisgenetRdfVersion.UNSUPPORTED;
 
     @Test
     public void testVersionRetriever1() throws InvalidStringFormatException {
@@ -43,11 +42,9 @@ public class DisgenetRdfVersionTester {
         Assert.assertEquals(actual, rdfV5);
     }
 
-    @Test
+    @Test(expectedExceptions = EnumConstantNotPresentException.class)
     public void testVersionRetriever6() throws InvalidStringFormatException {
-        DisgenetRdfVersion actual = DisgenetRdfVersion.retrieve("50");
-
-        Assert.assertEquals(actual, rdfUnsupported);
+        DisgenetRdfVersion.retrieve("50");
     }
 
     @Test(expectedExceptions = InvalidStringFormatException.class)

--- a/src/test/java/org/molgenis/vibe/query_output_digestion/prioritization/DiseasePleiotropyIndexGenePrioritizerTester.java
+++ b/src/test/java/org/molgenis/vibe/query_output_digestion/prioritization/DiseasePleiotropyIndexGenePrioritizerTester.java
@@ -1,0 +1,31 @@
+package org.molgenis.vibe.query_output_digestion.prioritization;
+
+import org.molgenis.vibe.formats.Gene;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class DiseasePleiotropyIndexGenePrioritizerTester {
+    @Test
+    public void testOrdering() {
+        List<Gene> genes = new ArrayList<>( Arrays.asList(
+                new Gene("ncbigene:1", "name1", "symbol1", 0.3, 0.3, URI.create("http://identifiers.org/ncbigene/1")),
+                new Gene("ncbigene:2", "name2", "symbol2", 0.2, 0.9, URI.create("http://identifiers.org/ncbigene/2")),
+                new Gene("ncbigene:3", "name3", "symbol3", 0.1, 0.5, URI.create("http://identifiers.org/ncbigene/3"))
+        ));
+
+        List<Gene> expectedPriority = new ArrayList<>( Arrays.asList(
+                genes.get(0), // 0.3 first
+                genes.get(2), // 0.5 second
+                genes.get(1) // 0.9 third
+        ));
+
+        GenePrioritizer prioritizer = new DiseasePleiotropyIndexGenePrioritizer(genes);
+        prioritizer.run();
+        Assert.assertEquals(prioritizer.getPriority(), expectedPriority);
+    }
+}

--- a/src/test/java/org/molgenis/vibe/query_output_digestion/prioritization/DiseaseSpecificityIndexGenePrioritizerTester.java
+++ b/src/test/java/org/molgenis/vibe/query_output_digestion/prioritization/DiseaseSpecificityIndexGenePrioritizerTester.java
@@ -1,0 +1,29 @@
+package org.molgenis.vibe.query_output_digestion.prioritization;
+
+import org.molgenis.vibe.formats.Gene;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.*;
+
+public class DiseaseSpecificityIndexGenePrioritizerTester {
+    @Test
+    public void testOrdering() {
+        List<Gene> genes = new ArrayList<>( Arrays.asList(
+                new Gene("ncbigene:1", "name1", "symbol1", 0.5, 0.1, URI.create("http://identifiers.org/ncbigene/1")),
+                new Gene("ncbigene:2", "name2", "symbol2", 0.8, 0.2, URI.create("http://identifiers.org/ncbigene/2")),
+                new Gene("ncbigene:3", "name3", "symbol3", 0.2, 0.3, URI.create("http://identifiers.org/ncbigene/3"))
+        ));
+
+        List<Gene> expectedPriority = new ArrayList<>( Arrays.asList(
+                genes.get(1), // 0.8 first
+                genes.get(0), // 0.5 second
+                genes.get(2) // 0.2 third
+        ));
+
+        GenePrioritizer prioritizer = new DiseaseSpecificityIndexGenePrioritizer(genes);
+        prioritizer.run();
+        Assert.assertEquals(prioritizer.getPriority(), expectedPriority);
+    }
+}

--- a/src/test/java/org/molgenis/vibe/rdf_processing/GenesForPhenotypeRetrieverTester.java
+++ b/src/test/java/org/molgenis/vibe/rdf_processing/GenesForPhenotypeRetrieverTester.java
@@ -40,11 +40,11 @@ public class GenesForPhenotypeRetrieverTester {
     @Test
     public void retrieveGeneDiseaseCollectionForMultiplePhenotypes() {
         Gene[] genes = new Gene[]{
-                new Gene("ncbigene:1311", "cartilage oligomeric matrix protein", "COMP", URI.create("http://identifiers.org/ncbigene/1311")), // umls:C0410538
-                new Gene("ncbigene:10082", "glypican 6", "GPC6", URI.create("http://identifiers.org/ncbigene/10082")), // umls:C1850318 & umls:C1968605
-                new Gene("ncbigene:960", "CD44 molecule (Indian blood group)", "CD44", URI.create("http://identifiers.org/ncbigene/960")), // umls:C1850318
-                new Gene("ncbigene:10075", "HECT, UBA and WWE domain containing 1, E3 ubiquitin protein ligase", "HUWE1", URI.create("http://identifiers.org/ncbigene/10075")), // umls:C1867103
-                new Gene("ncbigene:2261", "fibroblast growth factor receptor 3", "FGFR3", URI.create("http://identifiers.org/ncbigene/2261")), // umls:C1867103
+                new Gene("ncbigene:1311", "cartilage oligomeric matrix protein", "COMP", 0.507872279859934E0, 0.607142857142857E0, URI.create("http://identifiers.org/ncbigene/1311")), // umls:C0410538
+                new Gene("ncbigene:10082", "glypican 6", "GPC6", 0.596109001438773E0, 0.5E0, URI.create("http://identifiers.org/ncbigene/10082")), // umls:C1850318 & umls:C1968605
+                new Gene("ncbigene:960", "CD44 molecule (Indian blood group)", "CD44", 0.383591614803352E0, 0.821428571428571E0, URI.create("http://identifiers.org/ncbigene/960")), // umls:C1850318
+                new Gene("ncbigene:10075", "HECT, UBA and WWE domain containing 1, E3 ubiquitin protein ligase", "HUWE1", 0.625716589831481E0, 0.5E0, URI.create("http://identifiers.org/ncbigene/10075")), // umls:C1867103
+                new Gene("ncbigene:2261", "fibroblast growth factor receptor 3", "FGFR3", 0.366634840656414E0, 0.821428571428571E0, URI.create("http://identifiers.org/ncbigene/2261")), // umls:C1867103
         };
 
         Disease[] diseases = new Disease[]{
@@ -97,35 +97,11 @@ public class GenesForPhenotypeRetrieverTester {
         // General comparison (does not compare all content)
         Assert.assertEquals(actualCollection, expectedCollection);
 
-        // Goes through all gene-disease combinations.
-        for(Gene gene : actualCollection.getGenes()) {
-            for(Disease disease : actualCollection.getDiseases()) {
-                // Stores actual and expected combination.
-                GeneDiseaseCombination actualCombination = actualCollection.get(new GeneDiseaseCombination(gene, disease));
-                GeneDiseaseCombination expectedCombination = expectedCollection.get(new GeneDiseaseCombination(gene, disease));
-
-                // Not every combination actually has data.
-                if(expectedCombination != null) {
-                    // Compares all stored variables from the gene-disease combination gene not used in equals().
-                    Assert.assertEquals(actualCombination.getGene().getName(), expectedCombination.getGene().getName());
-                    Assert.assertEquals(actualCombination.getGene().getUri(), expectedCombination.getGene().getUri());
-                    Assert.assertEquals(actualCombination.getGene().getSymbol(), expectedCombination.getGene().getSymbol());
-
-                    // Compares all stored variables from the gene-disease combination disease not used in equals().
-                    Assert.assertEquals(actualCombination.getDisease().getName(), expectedCombination.getDisease().getName());
-                    Assert.assertEquals(actualCombination.getDisease().getUri(), expectedCombination.getDisease().getUri());
-
-                    // Compares other variables.
-                    Assert.assertEquals(actualCombination.getDisgenetScore(), expectedCombination.getDisgenetScore());
-                    Assert.assertEquals(actualCombination.getSourcesCount(), expectedCombination.getSourcesCount());
-                    Assert.assertEquals(actualCombination.getSourcesWithEvidence(), expectedCombination.getSourcesWithEvidence());
-
-                    // Compares the the evidence on a per-source level.
-                    for (Source source : actualCombination.getSourcesWithEvidence()) {
-                        Assert.assertEquals(actualCombination.getEvidenceForSource(source), expectedCombination.getEvidenceForSource(source));
-                    }
-                }
-            }
-        }
+        // Above assert only compares equals. Certain classes might store additional data that should not play a role
+        // when validating equality but should be checked on whether they were loaded from the database correctly. An
+        // example of this would be a score belonging to a Gene. While it should not make it a "different" Gene, it does
+        // describe the Gene. For this reason, toString() is used as extra validation (with the assumption that these
+        // extra fields are mentioned in toString()).
+        Assert.assertEquals(actualCollection.toString(), expectedCollection.toString());
     }
 }

--- a/src/test/java/org/molgenis/vibe/rdf_processing/query_string_creation/DisgenetAssociationTypeTester.java
+++ b/src/test/java/org/molgenis/vibe/rdf_processing/query_string_creation/DisgenetAssociationTypeTester.java
@@ -54,10 +54,9 @@ public class DisgenetAssociationTypeTester {
         Assert.assertEquals(type.getFormattedId(), "sio:SIO_000983");
     }
 
-    @Test
+    @Test(expectedExceptions = EnumConstantNotPresentException.class)
     public void useNonExistingSio() throws InvalidStringFormatException {
-        DisgenetAssociationType type = DisgenetAssociationType.retrieve("999999");
-        Assert.assertNull(type);
+        DisgenetAssociationType.retrieve("999999");
     }
 
     @Test(expectedExceptions = InvalidStringFormatException.class)

--- a/src/test/java/org/molgenis/vibe/rdf_processing/query_string_creation/DisgenetQueryStringGeneratorTester.java
+++ b/src/test/java/org/molgenis/vibe/rdf_processing/query_string_creation/DisgenetQueryStringGeneratorTester.java
@@ -105,7 +105,7 @@ public class DisgenetQueryStringGeneratorTester extends QueryTester {
     @Test
     public void testGdaForGenes() {
         Set<Gene> genes = new HashSet<>();
-        genes.add(new Gene("ncbigene:1291", "collagen type II alpha 1 chain", "COL2A1", URI.create("http://identifiers.org/ncbigene/1291")));
+        genes.add(new Gene("ncbigene:1291", "collagen type II alpha 1 chain", "COL2A1", 0.393643700083081E0, 0.75E0, URI.create("http://identifiers.org/ncbigene/1291")));
 
         String[] fieldOrder = {"gene", "disease", "diseaseId", "diseaseTitle", "gdaScoreNumber", "gdaSource", "evidence"};
 

--- a/testng.xml
+++ b/testng.xml
@@ -15,17 +15,6 @@
         </packages>
     </test>
 
-    <test name="FailedTestsCausedByDependency" enabled="false">
-        <groups>
-            <run>
-                <include name="dependencyBug" />
-            </run>
-        </groups>
-        <packages>
-            <package name="org.molgenis.vibe.*" />
-        </packages>
-    </test>
-
     <!-- Require the full DisGeNET TDB to be available! -->
     <test name="Benchmarking" enabled="false">
         <groups>

--- a/testng.xml
+++ b/testng.xml
@@ -7,7 +7,6 @@
             <run>
                 <exclude name="benchmarking" />
                 <exclude name="noTest" />
-                <exclude name="dependencyBug" />
             </run>
         </groups>
         <packages>


### PR DESCRIPTION
- Retrieves additional scores (and added these to the output).
- Added additional GenePrioritizers (includes a factory for defining which one to use).
- Adjustments to command line digestion.
- EnumTypeDefiner now throws Exception instead of null if no match found.
- Adjustments to test code.
- Simplified testing for SPARQL query retrieval (assumes toString() returns all vital data).
- Uses new test archive.