### PR TITLE
Fixed incorrect maven versioning.

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.molgenis</groupId>
     <artifactId>vibe</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>


### PR DESCRIPTION
Maven versioning wasn't done correctly up until now. Additionally, "-SNAPSHOT" was missing in the pom.xml file.