### PR TITLE
Command line adjusted to contain several universal arguments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,13 @@
     </distributionManagement>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+
         <pluginManagement>
             <plugins>
                 <!-- define java version -->

--- a/vibe-cli/pom.xml
+++ b/vibe-cli/pom.xml
@@ -10,12 +10,8 @@
     <artifactId>vibe-cli</artifactId>
     <packaging>jar</packaging>
 
-    <properties>
-        <!-- fat jar name -->
-        <jar.fat>vibe-with-dependencies-${project.version}</jar.fat>
-    </properties>
-
     <build>
+        <finalName>vibe-with-dependencies-${project.version}</finalName>
         <testResources>
             <testResource>
                 <directory>src/test/resources</directory>
@@ -60,12 +56,6 @@
                                 <!-- prevents only single notice being presents and generates an overarching one instead -->
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
                             </transformers>
-                            <!-- file name of shaded jar -->
-                            <finalName>${jar.fat}</finalName>
-                            <!-- can be used instead of finalName to generate artifact with name submodule + postfix-->
-<!--                            <shadedClassifierName>with-dependencies</shadedClassifierName>-->
-                            <!-- due to finalname original artifact is treated as main artifact, this ensure both get a checksum -->
-                            <shadedArtifactAttached>true</shadedArtifactAttached>
                         </configuration>
                     </execution>
                 </executions>

--- a/vibe-cli/src/main/java/org/molgenis/vibe/cli/RunMode.java
+++ b/vibe-cli/src/main/java/org/molgenis/vibe/cli/RunMode.java
@@ -1,6 +1,8 @@
 package org.molgenis.vibe.cli;
 
 import org.apache.jena.ext.com.google.common.base.Stopwatch;
+import org.molgenis.vibe.cli.io.options_digestion.CommandLineOptionsParser;
+import org.molgenis.vibe.cli.properties.VibeProperties;
 import org.molgenis.vibe.core.GeneDiseaseCollectionRetrievalRunner;
 import org.molgenis.vibe.core.PhenotypesRetrievalRunner;
 import org.molgenis.vibe.cli.io.options_digestion.VibeOptions;
@@ -19,9 +21,15 @@ import java.util.Set;
  * Describes what the application should do.
  */
 public enum RunMode {
-    NONE("none") {
+    HELP("Show help message.") {
         @Override
         protected void runMode(VibeOptions vibeOptions, Stopwatch stopwatch) {
+            CommandLineOptionsParser.printHelpMessage();
+        }
+    }, VERSION("Show application version.") {
+        @Override
+        protected void runMode(VibeOptions vibeOptions, Stopwatch stopwatch) {
+            System.out.println(VibeProperties.APP_VERSION.getValue());
         }
     }, GENES_FOR_PHENOTYPES_WITH_ASSOCIATED_PHENOTYPES("Retrieves genes for input phenotypes and phenotypes associated to input phenotypes.") {
         @Override

--- a/vibe-cli/src/main/java/org/molgenis/vibe/cli/RunMode.java
+++ b/vibe-cli/src/main/java/org/molgenis/vibe/cli/RunMode.java
@@ -3,7 +3,6 @@ package org.molgenis.vibe.cli;
 import org.apache.jena.ext.com.google.common.base.Stopwatch;
 import org.molgenis.vibe.core.GeneDiseaseCollectionRetrievalRunner;
 import org.molgenis.vibe.core.PhenotypesRetrievalRunner;
-import org.molgenis.vibe.cli.io.options_digestion.CommandLineOptionsParser;
 import org.molgenis.vibe.cli.io.options_digestion.VibeOptions;
 import org.molgenis.vibe.core.formats.Gene;
 import org.molgenis.vibe.core.formats.GeneDiseaseCollection;
@@ -23,7 +22,6 @@ public enum RunMode {
     NONE("none") {
         @Override
         protected void runMode(VibeOptions vibeOptions, Stopwatch stopwatch) {
-            CommandLineOptionsParser.printHelpMessage();
         }
     }, GENES_FOR_PHENOTYPES_WITH_ASSOCIATED_PHENOTYPES("Retrieves genes for input phenotypes and phenotypes associated to input phenotypes.") {
         @Override

--- a/vibe-cli/src/main/java/org/molgenis/vibe/cli/VibeApplication.java
+++ b/vibe-cli/src/main/java/org/molgenis/vibe/cli/VibeApplication.java
@@ -16,37 +16,39 @@ public class VibeApplication {
      * @param args {@link String}{@code []}
      */
     public static void main(String[] args) {
-        loadPropertiesFile();
+        if ( loadPropertiesFile() ) { // If properties file loading succeeded, continues.
+            try {
+                // Parses user-input.
+                VibeOptions vibeOptions = new VibeOptions();
+                CommandLineOptionsParser.parse(args, vibeOptions);
 
-        try {
-            // Parses user-input.
-            VibeOptions vibeOptions = new VibeOptions();
-            CommandLineOptionsParser.parse(args, vibeOptions);
-
-            // If all input correctly parsed, runs app.
-            if(vibeOptions.validate()) {
-                executeRunMode(vibeOptions);
-            } else { // Errors caused by invalid options configuration.
-                printUnexpectedExceptionOccurred();
-                vibeOptions.toString();
+                // If all input correctly parsed, runs app.
+                if (vibeOptions.validate()) {
+                    executeRunMode(vibeOptions);
+                } else { // Errors caused by invalid options configuration.
+                    printUnexpectedExceptionOccurred();
+                    vibeOptions.toString();
+                }
+            } catch (ParseException e) { // Errors generated during options parsing.
+                System.err.println(e.getLocalizedMessage());
+                CommandLineOptionsParser.printHelpMessage();
             }
-        } catch (ParseException e) { // Errors generated during options parsing.
-            System.err.println(e.getLocalizedMessage());
-            CommandLineOptionsParser.printHelpMessage();
         }
     }
 
     /**
      * Parses application properties.
      * <b>Should always be ran first (as it sets the values for the VibeProperties enum)!</b>
+     * @return {@code true} if property file was loaded, {@code false} if it failed to do so
      */
-    private static void loadPropertiesFile() {
+    private static boolean loadPropertiesFile() {
         try {
             VibePropertiesLoader.loadProperties();
         } catch (IOException e) {
-            printUnexpectedExceptionOccurred();
-            e.printStackTrace();
+            System.err.println("Failed to load properties file. Please contact the developer.");
+            return false;
         }
+        return true;
     }
 
     /**

--- a/vibe-cli/src/main/java/org/molgenis/vibe/cli/VibeApplication.java
+++ b/vibe-cli/src/main/java/org/molgenis/vibe/cli/VibeApplication.java
@@ -15,11 +15,9 @@ public class VibeApplication {
      * @param args {@link String}{@code []}
      */
     public static void main(String[] args) {
+        loadPropertiesFile();
+
         try {
-            // Parses application properties.
-            // Should always be ran first (as it sets the values for the VibeProperties enum)!
-            VibePropertiesLoader.loadProperties();
-            
             // Parses user-input.
             VibeOptions vibeOptions = new VibeOptions();
             CommandLineOptionsParser.parse(args, vibeOptions);
@@ -34,6 +32,19 @@ public class VibeApplication {
         } catch (Exception e) { // Errors generated during options parsing.
             System.err.println(e.getLocalizedMessage());
             CommandLineOptionsParser.printHelpMessage();
+        }
+    }
+
+    /**
+     * Parses application properties.
+     * <b>Should always be ran first (as it sets the values for the VibeProperties enum)!</b>
+     */
+    private static void loadPropertiesFile() {
+        try {
+            VibePropertiesLoader.loadProperties();
+        } catch (IOException e) {
+            printUnexpectedExceptionOccurred();
+            e.printStackTrace();
         }
     }
 

--- a/vibe-cli/src/main/java/org/molgenis/vibe/cli/VibeApplication.java
+++ b/vibe-cli/src/main/java/org/molgenis/vibe/cli/VibeApplication.java
@@ -31,7 +31,6 @@ public class VibeApplication {
                 }
             } catch (ParseException e) { // Errors generated during options parsing.
                 System.err.println(e.getLocalizedMessage());
-                CommandLineOptionsParser.printHelpMessage();
             }
         }
     }

--- a/vibe-cli/src/main/java/org/molgenis/vibe/cli/VibeApplication.java
+++ b/vibe-cli/src/main/java/org/molgenis/vibe/cli/VibeApplication.java
@@ -1,5 +1,6 @@
 package org.molgenis.vibe.cli;
 
+import org.apache.commons.cli.ParseException;
 import org.molgenis.vibe.cli.io.options_digestion.CommandLineOptionsParser;
 import org.molgenis.vibe.cli.io.options_digestion.VibeOptions;
 import org.molgenis.vibe.cli.properties.VibePropertiesLoader;
@@ -29,7 +30,7 @@ public class VibeApplication {
                 printUnexpectedExceptionOccurred();
                 vibeOptions.toString();
             }
-        } catch (Exception e) { // Errors generated during options parsing.
+        } catch (ParseException e) { // Errors generated during options parsing.
             System.err.println(e.getLocalizedMessage());
             CommandLineOptionsParser.printHelpMessage();
         }

--- a/vibe-cli/src/main/java/org/molgenis/vibe/cli/VibeApplication.java
+++ b/vibe-cli/src/main/java/org/molgenis/vibe/cli/VibeApplication.java
@@ -2,6 +2,7 @@ package org.molgenis.vibe.cli;
 
 import org.molgenis.vibe.cli.io.options_digestion.CommandLineOptionsParser;
 import org.molgenis.vibe.cli.io.options_digestion.VibeOptions;
+import org.molgenis.vibe.cli.properties.VibePropertiesLoader;
 
 import java.io.IOException;
 
@@ -15,6 +16,10 @@ public class VibeApplication {
      */
     public static void main(String[] args) {
         try {
+            // Parses application properties.
+            // Should always be ran first (as it sets the values for the VibeProperties enum)!
+            VibePropertiesLoader.loadProperties();
+            
             // Parses user-input.
             VibeOptions vibeOptions = new VibeOptions();
             CommandLineOptionsParser.parse(args, vibeOptions);

--- a/vibe-cli/src/main/java/org/molgenis/vibe/cli/io/options_digestion/CommandLineOptionsParser.java
+++ b/vibe-cli/src/main/java/org/molgenis/vibe/cli/io/options_digestion/CommandLineOptionsParser.java
@@ -175,6 +175,7 @@ public abstract class CommandLineOptionsParser {
      * @throws NumberFormatException if user-input which should be an int could not be interpreted as one
      * @throws InvalidStringFormatException if user-input text does not adhere to required format (regex)
      */
+    @SuppressWarnings("java:S128")
     private static void digestCommandLine(CommandLine commandLine, VibeOptions vibeOptions)
             throws InvalidPathException, ParseException, NumberFormatException, InvalidStringFormatException {
         // Sets RunMode.

--- a/vibe-cli/src/main/java/org/molgenis/vibe/cli/io/options_digestion/CommandLineOptionsParser.java
+++ b/vibe-cli/src/main/java/org/molgenis/vibe/cli/io/options_digestion/CommandLineOptionsParser.java
@@ -40,10 +40,10 @@ public abstract class CommandLineOptionsParser {
      * Digests the command line arguments and stores this in a newly created {@link VibeOptions} instance.
      * @param args the command line arguments
      * @return a {@link VibeOptions} that contains the information from the command line
-     * @throws IOException see {@link #digestCommandLine(CommandLine, VibeOptions)}
-     * @throws ParseException see {@link #parseCommandLine(String[])}
+     * @throws ParseException see {@link #parseCommandLine(String[])} &
+     * {@link #digestCommandLine(CommandLine, VibeOptions)}
      */
-    public static VibeOptions parse(String[] args) throws IOException, ParseException {
+    public static VibeOptions parse(String[] args) throws ParseException {
         VibeOptions vibeOptions = new VibeOptions();
         parse(args, vibeOptions);
         return vibeOptions;
@@ -53,10 +53,10 @@ public abstract class CommandLineOptionsParser {
      * Digests the command line arguments and stores this in the supplied {@link VibeOptions} instance.
      * @param args the command line arguments
      * @param vibeOptions in which the digested command line arguments should be stored
-     * @throws IOException see {@link #digestCommandLine(CommandLine, VibeOptions)}
-     * @throws ParseException see {@link #parseCommandLine(String[])}
+     * @throws ParseException see {@link #parseCommandLine(String[])} &
+     * {@link #digestCommandLine(CommandLine, VibeOptions)}
      */
-    public static void parse(String[] args, VibeOptions vibeOptions) throws IOException, ParseException {
+    public static void parse(String[] args, VibeOptions vibeOptions) throws ParseException {
         CommandLine commandLine = parseCommandLine(args);
         digestCommandLine(commandLine, vibeOptions);
     }
@@ -171,12 +171,12 @@ public abstract class CommandLineOptionsParser {
      * @param commandLine the parsed command line
      * @param vibeOptions in which the parsed command line information should be stored
      * @throws InvalidPathException if user-input which should be a file/directory could not be converted to {@link Path}
-     * @throws IOException if invalid user-input was given (often due to unreadable/missing files)
+     * @throws ParseException if errors were encountered while parsing the command line arguments
      * @throws NumberFormatException if user-input which should be an int could not be interpreted as one
      * @throws InvalidStringFormatException if user-input text does not adhere to required format (regex)
      */
     private static void digestCommandLine(CommandLine commandLine, VibeOptions vibeOptions)
-            throws InvalidPathException, IOException, NumberFormatException, InvalidStringFormatException {
+            throws InvalidPathException, ParseException, NumberFormatException, InvalidStringFormatException {
         // Sets RunMode.
         defineRunMode(commandLine, vibeOptions);
 
@@ -185,7 +185,7 @@ public abstract class CommandLineOptionsParser {
 
         switch (vibeOptions.getRunMode()) {
             case GENES_FOR_PHENOTYPES:
-                // Checks for missing arguments, and if so, throws IOException.
+                // Checks for missing arguments, and if so, throws ParseException.
                 checkForMissingArguments(commandLine, vibeOptions);
 
                 // Digests the databases needed be the application.
@@ -204,9 +204,9 @@ public abstract class CommandLineOptionsParser {
 
         }
 
-        // Checks if any errors were created, and if so, throws IOException.
+        // Checks if any errors were created, and if so, throws ParseException.
         if(!errors.isEmpty()) {
-            throw new IOException(StringUtils.join(errors, System.lineSeparator()));
+            throw new ParseException(StringUtils.join(errors, System.lineSeparator()));
         }
     }
 
@@ -216,9 +216,9 @@ public abstract class CommandLineOptionsParser {
      * @param vibeOptions in which the parsed command line information should be stored
      */
     private static void defineRunMode(CommandLine commandLine, VibeOptions vibeOptions) {
-        if(commandLine.getOptions().length == 0 || commandLine.hasOption("h")) {
+        if (commandLine.getOptions().length == 0 || commandLine.hasOption("h")) {
             vibeOptions.setRunMode(RunMode.HELP);
-        } else if(commandLine.hasOption("v")) {
+        } else if (commandLine.hasOption("v")) {
             vibeOptions.setRunMode(RunMode.VERSION);
         } else if (commandLine.hasOption("n") || commandLine.hasOption("m")) {
             vibeOptions.setRunMode(RunMode.GENES_FOR_PHENOTYPES_WITH_ASSOCIATED_PHENOTYPES);
@@ -232,9 +232,9 @@ public abstract class CommandLineOptionsParser {
      * arguments require other arguments check if these are present as well, etc.)
      * @param commandLine the parsed command line
      * @param vibeOptions in which the parsed command line information should be stored
-     * @return a {@link List} containing all missing arguments, or an empty {@link List} if no arguments are missing
+     * @throws ParseException if any of the expected arguments is missing
      */
-    private static void checkForMissingArguments(CommandLine commandLine, VibeOptions vibeOptions) throws IOException {
+    private static void checkForMissingArguments(CommandLine commandLine, VibeOptions vibeOptions) throws ParseException {
         // Stores the missing expected arguments.
         List<String> missing = new ArrayList<>();
 
@@ -262,9 +262,9 @@ public abstract class CommandLineOptionsParser {
             }
         }
 
-        // Generates IOException with missing arguments if any were found.
+        // Generates ParseException with missing arguments if any were found.
         if(!missing.isEmpty()) {
-            throw new IOException("Missing arguments: " + StringUtils.join(missing, ", "));
+            throw new ParseException("Missing arguments: " + StringUtils.join(missing, ", "));
         }
     }
 

--- a/vibe-cli/src/main/java/org/molgenis/vibe/cli/io/options_digestion/CommandLineOptionsParser.java
+++ b/vibe-cli/src/main/java/org/molgenis/vibe/cli/io/options_digestion/CommandLineOptionsParser.java
@@ -153,10 +153,6 @@ public abstract class CommandLineOptionsParser {
         formatter.printHelp(80, cmdSyntax, helpHeader, options, helpFooter, false);
     }
 
-    public static void printVersion() {
-        System.out.println(VibeProperties.APP_VERSION.getValue());
-    }
-
     /**
      * Parses the command line with the possible arguments.
      *
@@ -184,29 +180,28 @@ public abstract class CommandLineOptionsParser {
         // Sets RunMode.
         defineRunMode(commandLine, vibeOptions);
 
-        // If RunMode is NONE, stops digesting command line.
-        if(vibeOptions.getRunMode() == RunMode.NONE) {
-            return; // IMPORTANT: Does not process any other arguments from this point.
-        }
-
-        // Checks for missing arguments, and if so, throws IOException.
-        checkForMissingArguments(commandLine, vibeOptions);
-
         // Stores errors produced by the given arguments.
         List<String> errors = new ArrayList<>();
 
-        // Digests the databases needed be the application.
-        digestDatabases(commandLine, vibeOptions, errors);
+        switch (vibeOptions.getRunMode()) {
+            case GENES_FOR_PHENOTYPES:
+                // Checks for missing arguments, and if so, throws IOException.
+                checkForMissingArguments(commandLine, vibeOptions);
 
-        // Digests the input phenotypes.
-        digestInputPhenotypes(commandLine, vibeOptions, errors);
+                // Digests the databases needed be the application.
+                digestDatabases(commandLine, vibeOptions, errors);
 
-        // Digests output arguments (including logging/verbosity).
-        digestOutputArguments(commandLine, vibeOptions, errors);
+                // Digests the input phenotypes.
+                digestInputPhenotypes(commandLine, vibeOptions, errors);
 
-        // Digests arguments related to the HPO ontology traversal.
-        if(vibeOptions.getRunMode() == RunMode.GENES_FOR_PHENOTYPES_WITH_ASSOCIATED_PHENOTYPES) {
-            digestHpoOntologyArguments(commandLine, vibeOptions, errors);
+                // Digests output arguments (including logging/verbosity).
+                digestOutputArguments(commandLine, vibeOptions, errors);
+            case GENES_FOR_PHENOTYPES_WITH_ASSOCIATED_PHENOTYPES:
+                // Digests arguments related to the HPO ontology traversal.
+                digestHpoOntologyArguments(commandLine, vibeOptions, errors);
+            default:
+                // For other cases (NONE, HELP, VERSION) no other arguments need to be digested.
+
         }
 
         // Checks if any errors were created, and if so, throws IOException.
@@ -222,11 +217,9 @@ public abstract class CommandLineOptionsParser {
      */
     private static void defineRunMode(CommandLine commandLine, VibeOptions vibeOptions) {
         if(commandLine.getOptions().length == 0 || commandLine.hasOption("h")) {
-            vibeOptions.setRunMode(RunMode.NONE);
-            CommandLineOptionsParser.printHelpMessage();
+            vibeOptions.setRunMode(RunMode.HELP);
         } else if(commandLine.hasOption("v")) {
-            vibeOptions.setRunMode(RunMode.NONE);
-            printVersion();
+            vibeOptions.setRunMode(RunMode.VERSION);
         } else if (commandLine.hasOption("n") || commandLine.hasOption("m")) {
             vibeOptions.setRunMode(RunMode.GENES_FOR_PHENOTYPES_WITH_ASSOCIATED_PHENOTYPES);
         } else {

--- a/vibe-cli/src/main/java/org/molgenis/vibe/cli/io/options_digestion/CommandLineOptionsParser.java
+++ b/vibe-cli/src/main/java/org/molgenis/vibe/cli/io/options_digestion/CommandLineOptionsParser.java
@@ -184,6 +184,11 @@ public abstract class CommandLineOptionsParser {
         List<String> errors = new ArrayList<>();
 
         switch (vibeOptions.getRunMode()) {
+            case GENES_FOR_PHENOTYPES_WITH_ASSOCIATED_PHENOTYPES:
+                // Digests arguments related to the HPO ontology traversal.
+                digestHpoOntologyArguments(commandLine, vibeOptions, errors);
+
+                // NO BREAK: continues!!!
             case GENES_FOR_PHENOTYPES:
                 // Checks for missing arguments, and if so, throws ParseException.
                 checkForMissingArguments(commandLine, vibeOptions);
@@ -196,9 +201,6 @@ public abstract class CommandLineOptionsParser {
 
                 // Digests output arguments (including logging/verbosity).
                 digestOutputArguments(commandLine, vibeOptions, errors);
-            case GENES_FOR_PHENOTYPES_WITH_ASSOCIATED_PHENOTYPES:
-                // Digests arguments related to the HPO ontology traversal.
-                digestHpoOntologyArguments(commandLine, vibeOptions, errors);
             default:
                 // For other cases (NONE, HELP, VERSION) no other arguments need to be digested.
 

--- a/vibe-cli/src/main/java/org/molgenis/vibe/cli/io/options_digestion/CommandLineOptionsParser.java
+++ b/vibe-cli/src/main/java/org/molgenis/vibe/cli/io/options_digestion/CommandLineOptionsParser.java
@@ -181,6 +181,9 @@ public abstract class CommandLineOptionsParser {
         // Sets RunMode.
         defineRunMode(commandLine, vibeOptions);
 
+        // Checks for missing arguments, and if so, throws ParseException.
+        checkForMissingArguments(commandLine, vibeOptions);
+
         // Stores errors produced by the given arguments.
         List<String> errors = new ArrayList<>();
 
@@ -191,9 +194,6 @@ public abstract class CommandLineOptionsParser {
 
                 // NO BREAK: continues!!!
             case GENES_FOR_PHENOTYPES:
-                // Checks for missing arguments, and if so, throws ParseException.
-                checkForMissingArguments(commandLine, vibeOptions);
-
                 // Digests the databases needed be the application.
                 digestDatabases(commandLine, vibeOptions, errors);
 
@@ -203,7 +203,7 @@ public abstract class CommandLineOptionsParser {
                 // Digests output arguments (including logging/verbosity).
                 digestOutputArguments(commandLine, vibeOptions, errors);
             default:
-                // For other cases (NONE, HELP, VERSION) no other arguments need to be digested.
+                // For other cases (HELP/VERSION) no other arguments need to be digested.
 
         }
 
@@ -238,6 +238,11 @@ public abstract class CommandLineOptionsParser {
      * @throws ParseException if any of the expected arguments is missing
      */
     private static void checkForMissingArguments(CommandLine commandLine, VibeOptions vibeOptions) throws ParseException {
+        // If help message or version is requested, there are no requirements.
+        if(vibeOptions.getRunMode() == RunMode.HELP || vibeOptions.getRunMode() == RunMode.VERSION) {
+            return;
+        }
+
         // Stores the missing expected arguments.
         List<String> missing = new ArrayList<>();
 

--- a/vibe-cli/src/main/java/org/molgenis/vibe/cli/io/options_digestion/VibeOptions.java
+++ b/vibe-cli/src/main/java/org/molgenis/vibe/cli/io/options_digestion/VibeOptions.java
@@ -299,6 +299,7 @@ public class VibeOptions {
      * user input to validate if variables are set correctly (based on the specified {@link RunMode}).
      * @return {@code true} if available variables adhere to {@link RunMode}, {@code false} if not
      */
+    @SuppressWarnings("java:S128")
     public boolean validate() {
         // With RunMode.NONE there are no requirements.
         if (!runMode.equals(RunMode.NONE)) {

--- a/vibe-cli/src/main/java/org/molgenis/vibe/cli/io/options_digestion/VibeOptions.java
+++ b/vibe-cli/src/main/java/org/molgenis/vibe/cli/io/options_digestion/VibeOptions.java
@@ -10,6 +10,7 @@ import org.molgenis.vibe.cli.io.output.target.OutputWriter;
 import org.molgenis.vibe.core.ontology_processing.PhenotypesRetrieverFactory;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.file.*;
 import java.util.HashSet;
 import java.util.Set;
@@ -233,9 +234,29 @@ public class VibeOptions {
      * @throws FileAlreadyExistsException if file already exists
      */
     protected void setFileOutputWriter(Path outputFile) throws FileAlreadyExistsException {
-        if(checkIfPathIsReadableFile(outputFile)) {
+        if(checkIfPathIsWritableFile(outputFile)) {
             throw new FileAlreadyExistsException(outputFile.getFileName() + " already exists.");
         }
+        this.outputWriter = new FileOutputWriter(outputFile);
+    }
+
+    /**
+     * Wrapper for {@link #setFileOutputWriterForced(Path)}.
+     * @param outputFile the file path to write the output to
+     * @throws InvalidPathException if {@code outputFile} could not be converted to {@link Path}
+     */
+    protected void setFileOutputWriterForced(String outputFile) throws InvalidPathException {
+        setFileOutputWriterForced(Paths.get(outputFile));
+    }
+
+    /**
+     * Sets the {@link OutputWriter} to a {@link FileOutputWriter}. Overrides any previously set {@link OutputWriter}.
+     * If an existing file is given, it will be overwritten.
+     * @param outputFile the file path to write the output to
+     * @see FileOutputWriter#initialize()
+     */
+    protected void setFileOutputWriterForced(Path outputFile) {
+        checkIfPathIsWritableFile(outputFile);
         this.outputWriter = new FileOutputWriter(outputFile);
     }
 
@@ -253,6 +274,15 @@ public class VibeOptions {
      */
     private boolean checkIfPathIsReadableFile(Path path) {
         return Files.isReadable(path) && Files.isRegularFile(path);
+    }
+
+    /**
+     * Checks if a given {@link Path} is an existing writable file.
+     * @param path {@link Path}
+     * @return {@code boolean} {@code true} if so, otherwise {@code false}
+     */
+    private boolean checkIfPathIsWritableFile(Path path) {
+        return Files.isWritable(path) && Files.isRegularFile(path);
     }
 
     /**

--- a/vibe-cli/src/main/java/org/molgenis/vibe/cli/io/options_digestion/VibeOptions.java
+++ b/vibe-cli/src/main/java/org/molgenis/vibe/cli/io/options_digestion/VibeOptions.java
@@ -10,7 +10,6 @@ import org.molgenis.vibe.cli.io.output.target.OutputWriter;
 import org.molgenis.vibe.core.ontology_processing.PhenotypesRetrieverFactory;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.file.*;
 import java.util.HashSet;
 import java.util.Set;
@@ -301,50 +300,64 @@ public class VibeOptions {
      */
     @SuppressWarnings("java:S128")
     public boolean validate() {
-        // With RunMode.NONE there are no requirements.
-        if (!runMode.equals(RunMode.NONE)) {
-            // Check if DisGeNET data is set.
-            if (getVibeTdb() == null) {
-                return false;
-            }
-            // Check if HPO ontology data is set.
-            if (getHpoOntology() == null) {
-                return false;
-            }
-            // Check if an output file was given.
-            if (getOutputWriter() == null) {
-                return false;
-            }
-            // Checks if a gene prioritized output format factory was given.
-            if (getGenePrioritizedOutputFormatWriterFactory() == null) {
-                return false;
-            }
-            // Check config specific settings are set.
-            switch (runMode) {
-                // Additional checks if related HPOs need to be retrieved.
-                case GENES_FOR_PHENOTYPES_WITH_ASSOCIATED_PHENOTYPES:
-                    // Check if a factory for related HPO retrieval was set.
-                    if (getPhenotypesRetrieverFactory() == null) {
-                        return false;
-                    }
-                    // Check if a max distance for related HPO retrieval was set.
-                    if (getOntologyMaxDistance() == null) {
-                        return false;
-                    }
-                    // NO BREAK: continues!!!
-
-                    // Checks if no associated phenotypes need to be retrieved.
-                case GENES_FOR_PHENOTYPES:
-                    // Check if there are any input phenotypes.
-                    if (getPhenotypes().isEmpty()) {
-                        return false;
-                    }
-                default:
-                    // No additional checks required for non-specified cases.
-            }
+        switch (runMode) {
+            case GENES_FOR_PHENOTYPES_WITH_ASSOCIATED_PHENOTYPES:
+                if(!validateRelatedPhenotypesRetrieval()) return false;
+                // NO BREAK: continues!!!
+            case GENES_FOR_PHENOTYPES:
+                if(!validateGenesForPhenotype()) return false;
+            default:
+                // No checks required for non-specified cases.
         }
 
         // If nothing failed, returns true.
+        return true;
+    }
+
+    /**
+     * Checks whether variables were set that are only required for retrieving related {@link Phenotype}{@code s} for
+     * the input {@link Phenotype}{@code s}.
+     * @return {@code true} if all needed variables are set, otherwise {@code false}
+     */
+    private boolean validateRelatedPhenotypesRetrieval() {
+        // Check if a factory for related HPO retrieval was set.
+        if (getPhenotypesRetrieverFactory() == null) {
+            return false;
+        }
+        // Check if a max distance for related HPO retrieval was set.
+        if (getOntologyMaxDistance() == null) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Checks whether variables were set that are required for retrieving a
+     * {@link org.molgenis.vibe.core.formats.GeneDiseaseCollection} from the {@code TDB} using
+     * {@link Phenotype}{@code s} as input.
+     * @return {@code true} if all needed variables are set, otherwise {@code false}
+     */
+    private boolean validateGenesForPhenotype() {
+        // Check if DisGeNET data is set.
+        if (getVibeTdb() == null) {
+            return false;
+        }
+        // Check if HPO ontology data is set.
+        if (getHpoOntology() == null) {
+            return false;
+        }
+        // Check if an output writer was given.
+        if (getOutputWriter() == null) {
+            return false;
+        }
+        // Checks if a gene prioritized output format factory was given.
+        if (getGenePrioritizedOutputFormatWriterFactory() == null) {
+            return false;
+        }
+        // Check if there are any input phenotypes.
+        if (getPhenotypes().isEmpty()) {
+            return false;
+        }
         return true;
     }
 

--- a/vibe-cli/src/main/java/org/molgenis/vibe/cli/io/options_digestion/VibeOptions.java
+++ b/vibe-cli/src/main/java/org/molgenis/vibe/cli/io/options_digestion/VibeOptions.java
@@ -317,6 +317,8 @@ public class VibeOptions {
     /**
      * Checks whether variables were set that are only required for retrieving related {@link Phenotype}{@code s} for
      * the input {@link Phenotype}{@code s}.
+     * <br /><br />
+     * <b>IMPORTANT:</b> Requirements that are checked in {@link #validateGenesForPhenotype()} are skipped here!
      * @return {@code true} if all needed variables are set, otherwise {@code false}
      */
     private boolean validateRelatedPhenotypesRetrieval() {

--- a/vibe-cli/src/main/java/org/molgenis/vibe/cli/properties/VibeProperties.java
+++ b/vibe-cli/src/main/java/org/molgenis/vibe/cli/properties/VibeProperties.java
@@ -1,0 +1,20 @@
+package org.molgenis.vibe.cli.properties;
+
+/**
+ * Properties (parsed by {@link VibePropertiesLoader}) stored in {@code application.properties} accessible anywhere in
+ * the app (so {@link VibePropertiesLoader} should always be used first to parse the properties).
+ */
+public enum VibeProperties {
+    APP_NAME,
+    APP_VERSION;
+
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/vibe-cli/src/main/java/org/molgenis/vibe/cli/properties/VibePropertiesLoader.java
+++ b/vibe-cli/src/main/java/org/molgenis/vibe/cli/properties/VibePropertiesLoader.java
@@ -1,0 +1,26 @@
+package org.molgenis.vibe.cli.properties;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * Loads the properties stored in {@code application.properties} for usage by {@link VibeProperties}. Should be the first
+ * class called in the app before anything else by the {@code start-class}.
+ */
+public class VibePropertiesLoader {
+    private static final String propertiesFileName = "application.properties";
+
+    public static void loadProperties() throws IOException {
+        Properties properties = new Properties();
+
+        try ( InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(propertiesFileName) ) {
+            // Load properties.
+            properties.load(inputStream);
+
+            // Set variables.
+            VibeProperties.APP_NAME.setValue(properties.getProperty("app.name"));
+            VibeProperties.APP_VERSION.setValue(properties.getProperty("app.version"));
+        }
+    }
+}

--- a/vibe-cli/src/main/java/org/molgenis/vibe/cli/properties/VibePropertiesLoader.java
+++ b/vibe-cli/src/main/java/org/molgenis/vibe/cli/properties/VibePropertiesLoader.java
@@ -9,12 +9,12 @@ import java.util.Properties;
  * class called in the app before anything else by the {@code start-class}.
  */
 public class VibePropertiesLoader {
-    private static final String propertiesFileName = "application.properties";
+    private static final String PROPERTIES_FILE_NAME = "application.properties";
 
     public static void loadProperties() throws IOException {
         Properties properties = new Properties();
 
-        try ( InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(propertiesFileName) ) {
+        try ( InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(PROPERTIES_FILE_NAME) ) {
             // Load properties.
             properties.load(inputStream);
 

--- a/vibe-cli/src/main/java/org/molgenis/vibe/cli/properties/VibePropertiesLoader.java
+++ b/vibe-cli/src/main/java/org/molgenis/vibe/cli/properties/VibePropertiesLoader.java
@@ -11,6 +11,9 @@ import java.util.Properties;
 public class VibePropertiesLoader {
     private static final String PROPERTIES_FILE_NAME = "application.properties";
 
+    private VibePropertiesLoader() {
+    }
+
     public static void loadProperties() throws IOException {
         Properties properties = new Properties();
 

--- a/vibe-cli/src/main/resources/application.properties
+++ b/vibe-cli/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+app.name=@parent.name@
+app.version=@project.version@

--- a/vibe-cli/src/test/java/org/molgenis/vibe/cli/io/options_digestion/CommandLineOptionsParserTest.java
+++ b/vibe-cli/src/test/java/org/molgenis/vibe/cli/io/options_digestion/CommandLineOptionsParserTest.java
@@ -201,7 +201,7 @@ class CommandLineOptionsParserTest {
     }
 
     @Test
-    public void validSingleHpoWithoutOntologyTraversalUsingExstingOutputFileWithoutOverwrite() {
+    void validSingleHpoWithoutOntologyTraversalUsingExstingOutputFileWithoutOverwrite() {
         String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, VALID_HPO_SINGLE, OUTPUT_FILE_EXISTING);
 
         Exception exception = Assertions.assertThrows(ParseException.class, () -> CommandLineOptionsParser.parse(args) );

--- a/vibe-cli/src/test/java/org/molgenis/vibe/cli/io/options_digestion/CommandLineOptionsParserTest.java
+++ b/vibe-cli/src/test/java/org/molgenis/vibe/cli/io/options_digestion/CommandLineOptionsParserTest.java
@@ -63,7 +63,7 @@ class CommandLineOptionsParserTest {
         String[] args = stringArraysMerger(HELP);
         VibeOptions vibeOptions = CommandLineOptionsParser.parse(args);
 
-        Assertions.assertEquals(RunMode.NONE, vibeOptions.getRunMode());
+        Assertions.assertEquals(RunMode.HELP, vibeOptions.getRunMode());
     }
 
     @Test
@@ -71,7 +71,7 @@ class CommandLineOptionsParserTest {
         String[] args = stringArraysMerger(VERSION);
         VibeOptions vibeOptions = CommandLineOptionsParser.parse(args);
 
-        Assertions.assertEquals(RunMode.NONE, vibeOptions.getRunMode());
+        Assertions.assertEquals(RunMode.VERSION, vibeOptions.getRunMode());
     }
 
     @Test
@@ -79,7 +79,7 @@ class CommandLineOptionsParserTest {
         String[] args = stringArraysMerger(new String[]{""});
         VibeOptions vibeOptions = CommandLineOptionsParser.parse(args);
 
-        Assertions.assertEquals(RunMode.NONE, vibeOptions.getRunMode());
+        Assertions.assertEquals(RunMode.HELP, vibeOptions.getRunMode());
     }
 
     @Test

--- a/vibe-cli/src/test/java/org/molgenis/vibe/cli/io/options_digestion/CommandLineOptionsParserTest.java
+++ b/vibe-cli/src/test/java/org/molgenis/vibe/cli/io/options_digestion/CommandLineOptionsParserTest.java
@@ -13,7 +13,6 @@ import org.molgenis.vibe.cli.io.output.target.FileOutputWriter;
 import org.molgenis.vibe.cli.io.output.target.StdoutOutputWriter;
 import org.molgenis.vibe.core.ontology_processing.PhenotypesRetrieverFactory;
 
-import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -59,7 +58,7 @@ class CommandLineOptionsParserTest {
     private final String[] OUTPUT_FILE_EXISTING = new String[]{"-o", TestData.EXISTING_TSV.getFullPathString()};
 
     @Test
-    void helpMessage() throws IOException, ParseException {
+    void helpMessage() throws ParseException {
         String[] args = stringArraysMerger(HELP);
         VibeOptions vibeOptions = CommandLineOptionsParser.parse(args);
 
@@ -67,7 +66,7 @@ class CommandLineOptionsParserTest {
     }
 
     @Test
-    void versionMessage() throws IOException, ParseException {
+    void versionMessage() throws ParseException {
         String[] args = stringArraysMerger(VERSION);
         VibeOptions vibeOptions = CommandLineOptionsParser.parse(args);
 
@@ -75,7 +74,7 @@ class CommandLineOptionsParserTest {
     }
 
     @Test
-    void noArguments() throws IOException, ParseException {
+    void noArguments() throws ParseException {
         String[] args = stringArraysMerger(new String[]{""});
         VibeOptions vibeOptions = CommandLineOptionsParser.parse(args);
 
@@ -83,7 +82,7 @@ class CommandLineOptionsParserTest {
     }
 
     @Test
-    void validSingleHpoWithoutOntologyTraversalUsingDefaultOutputFile() throws IOException, ParseException {
+    void validSingleHpoWithoutOntologyTraversalUsingDefaultOutputFile() throws ParseException {
         String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, VALID_HPO_SINGLE, OUTPUT_FILE_NEW);
         VibeOptions vibeOptions = CommandLineOptionsParser.parse(args);
 
@@ -98,7 +97,7 @@ class CommandLineOptionsParserTest {
     }
 
     @Test
-    void validSingleHpoWithoutOntologyTraversalUsingDefaultOutputFileWithVerbose() throws IOException, ParseException {
+    void validSingleHpoWithoutOntologyTraversalUsingDefaultOutputFileWithVerbose() throws ParseException {
         String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, VALID_HPO_SINGLE, OUTPUT_FILE_NEW, DEBUG);
         VibeOptions vibeOptions = CommandLineOptionsParser.parse(args);
 
@@ -112,7 +111,7 @@ class CommandLineOptionsParserTest {
     }
 
     @Test
-    void validSingleHpoWithoutOntologyTraversalUsingUriOutputFile() throws IOException, ParseException {
+    void validSingleHpoWithoutOntologyTraversalUsingUriOutputFile() throws ParseException {
         String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, VALID_HPO_SINGLE, OUTPUT_FILE_NEW, URIS_OUT);
         VibeOptions vibeOptions = CommandLineOptionsParser.parse(args);
 
@@ -125,7 +124,7 @@ class CommandLineOptionsParserTest {
     }
 
     @Test
-    void validSingleHpoWithoutOntologyTraversalUsingSimplifiedOutputFile() throws IOException, ParseException {
+    void validSingleHpoWithoutOntologyTraversalUsingSimplifiedOutputFile() throws ParseException {
         String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, VALID_HPO_SINGLE, OUTPUT_FILE_NEW, SIMPLIFIED_OUT);
         VibeOptions vibeOptions = CommandLineOptionsParser.parse(args);
 
@@ -138,7 +137,7 @@ class CommandLineOptionsParserTest {
     }
 
     @Test
-    void validSingleHpoWithoutOntologyTraversalUsingStdoutOutput() throws IOException, ParseException {
+    void validSingleHpoWithoutOntologyTraversalUsingStdoutOutput() throws ParseException {
         String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, VALID_HPO_SINGLE);
         VibeOptions vibeOptions = CommandLineOptionsParser.parse(args);
 
@@ -151,7 +150,7 @@ class CommandLineOptionsParserTest {
     }
 
     @Test
-    void validSingleHpoWithHpoAlgorithmChildren() throws IOException, ParseException {
+    void validSingleHpoWithHpoAlgorithmChildren() throws ParseException {
         String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, HPO_ALGORITHM_CHILDREN, VALID_DISTANCE, VALID_HPO_SINGLE, OUTPUT_FILE_NEW);
         VibeOptions vibeOptions = CommandLineOptionsParser.parse(args);
 
@@ -162,7 +161,7 @@ class CommandLineOptionsParserTest {
     }
 
     @Test
-    void validSingleHpoWithHpoAlgorithmDistance() throws IOException, ParseException {
+    void validSingleHpoWithHpoAlgorithmDistance() throws ParseException {
         String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, HPO_ALGORITHM_DISTANCE, VALID_DISTANCE, VALID_HPO_SINGLE, OUTPUT_FILE_NEW);
         VibeOptions vibeOptions = CommandLineOptionsParser.parse(args);
 
@@ -173,7 +172,7 @@ class CommandLineOptionsParserTest {
     }
 
     @Test
-    void validTwoHpos() throws IOException, ParseException {
+    void validTwoHpos() throws ParseException {
         String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, VALID_HPO_MULTIPLE, OUTPUT_FILE_NEW);
         VibeOptions vibeOptions = CommandLineOptionsParser.parse(args);
 
@@ -187,7 +186,7 @@ class CommandLineOptionsParserTest {
     }
 
     @Test
-    void validSingleHpoWithoutOntologyTraversalUsingExstingOutputFileWithOverwrite() throws IOException, ParseException {
+    void validSingleHpoWithoutOntologyTraversalUsingExstingOutputFileWithOverwrite() throws ParseException {
         String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, VALID_HPO_SINGLE, OUTPUT_FILE_EXISTING, FORCE_OVERWRITE);
         VibeOptions vibeOptions = CommandLineOptionsParser.parse(args);
 
@@ -205,7 +204,7 @@ class CommandLineOptionsParserTest {
     public void validSingleHpoWithoutOntologyTraversalUsingExstingOutputFileWithoutOverwrite() {
         String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, VALID_HPO_SINGLE, OUTPUT_FILE_EXISTING);
 
-        Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
+        Exception exception = Assertions.assertThrows(ParseException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals(TestData.EXISTING_TSV.getName() + " already exists.", exception.getMessage());
     }
 
@@ -213,7 +212,7 @@ class CommandLineOptionsParserTest {
     void validSingleHpoWithInvalidHpoAlgorithm() {
         String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, HPO_ALGORITHM_INVALID, VALID_DISTANCE, VALID_HPO_SINGLE, OUTPUT_FILE_NEW);
 
-        Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
+        Exception exception = Assertions.assertThrows(ParseException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals(HPO_ALGORITHM_INVALID[1] + " is not a valid HPO retrieval algorithm.", exception.getMessage());
     }
 
@@ -221,7 +220,7 @@ class CommandLineOptionsParserTest {
     void validSingleHpoWithInvalidHpoAlgorithmDistanceNumber() {
         String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, HPO_ALGORITHM_CHILDREN, INVALID_DISTANCE_NUMBER, VALID_HPO_SINGLE, OUTPUT_FILE_NEW);
 
-        Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
+        Exception exception = Assertions.assertThrows(ParseException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals(INVALID_DISTANCE_NUMBER[1] + " is not a valid HPO retrieval algorithm distance (must be a number >= 0).", exception.getMessage());
     }
 
@@ -229,7 +228,7 @@ class CommandLineOptionsParserTest {
     void validSingleHpoWithInvalidHpoAlgorithmDistanceString() {
         String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, HPO_ALGORITHM_CHILDREN, INVALID_DISTANCE_STRING, VALID_HPO_SINGLE, OUTPUT_FILE_NEW);
 
-        Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
+        Exception exception = Assertions.assertThrows(ParseException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals(INVALID_DISTANCE_STRING[1] + " is not a valid HPO retrieval algorithm distance (must be a number >= 0).", exception.getMessage());
     }
 
@@ -237,7 +236,7 @@ class CommandLineOptionsParserTest {
     void missingTdbAndHpoOntology() {
         String[] args = stringArraysMerger(VALID_HPO_SINGLE);
 
-        Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
+        Exception exception = Assertions.assertThrows(ParseException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals("Missing arguments: -t, -w", exception.getMessage());
     }
 
@@ -245,7 +244,7 @@ class CommandLineOptionsParserTest {
     void missingTdb() {
         String[] args = stringArraysMerger(VALID_HPO_SINGLE, VALID_ONTOLOGY);
 
-        Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
+        Exception exception = Assertions.assertThrows(ParseException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals("Missing arguments: -t", exception.getMessage());
     }
 
@@ -253,7 +252,7 @@ class CommandLineOptionsParserTest {
     void missingOntology() {
         String[] args = stringArraysMerger(VALID_HPO_SINGLE, VALID_TDB);
 
-        Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
+        Exception exception = Assertions.assertThrows(ParseException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals("Missing arguments: -w", exception.getMessage());
     }
 
@@ -261,7 +260,7 @@ class CommandLineOptionsParserTest {
     void noOntologyWithHpoAlgorithm() {
         String[] args = stringArraysMerger(VALID_TDB, HPO_ALGORITHM_CHILDREN, VALID_HPO_SINGLE, OUTPUT_FILE_NEW);
 
-        Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
+        Exception exception = Assertions.assertThrows(ParseException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals("Missing arguments: -w, -m", exception.getMessage());
     }
 
@@ -269,7 +268,7 @@ class CommandLineOptionsParserTest {
     void noOntologyWithHpoMaxDistance() {
         String[] args = stringArraysMerger(VALID_TDB, VALID_DISTANCE, VALID_HPO_SINGLE, OUTPUT_FILE_NEW);
 
-        Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
+        Exception exception = Assertions.assertThrows(ParseException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals("Missing arguments: -w, -n", exception.getMessage());
     }
 
@@ -277,7 +276,7 @@ class CommandLineOptionsParserTest {
     void withOntologyAndDistanceMissingHpoAlgorithm() {
         String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, VALID_DISTANCE, VALID_HPO_SINGLE, OUTPUT_FILE_NEW);
 
-        Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
+        Exception exception = Assertions.assertThrows(ParseException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals("Missing arguments: -n", exception.getMessage());
     }
 
@@ -285,7 +284,7 @@ class CommandLineOptionsParserTest {
     void withOntologyAndAlgorithmMissingHpoMaxDistance() {
         String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, HPO_ALGORITHM_CHILDREN, VALID_HPO_SINGLE, OUTPUT_FILE_NEW);
 
-        Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
+        Exception exception = Assertions.assertThrows(ParseException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals("Missing arguments: -m", exception.getMessage());
     }
 
@@ -293,7 +292,7 @@ class CommandLineOptionsParserTest {
     void withOntologyAlgorithmAndDistanceButNoOntologyFile() {
         String[] args = stringArraysMerger(VALID_TDB, HPO_ALGORITHM_CHILDREN, VALID_DISTANCE, VALID_HPO_SINGLE, OUTPUT_FILE_NEW);
 
-        Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
+        Exception exception = Assertions.assertThrows(ParseException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals("Missing arguments: -w", exception.getMessage());
     }
 
@@ -301,7 +300,7 @@ class CommandLineOptionsParserTest {
     void missingPhenotype() {
         String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, OUTPUT_FILE_NEW);
 
-        Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
+        Exception exception = Assertions.assertThrows(ParseException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals("Missing arguments: -p", exception.getMessage());
     }
 
@@ -309,7 +308,7 @@ class CommandLineOptionsParserTest {
     void invalidPhenotype() {
         String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, INVALID_HPO, OUTPUT_FILE_NEW);
 
-        Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
+        Exception exception = Assertions.assertThrows(ParseException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals(INVALID_HPO[1] + " does not adhere the required format: ^(hp|HP):([0-9]{7})$", exception.getMessage());
     }
 
@@ -317,7 +316,7 @@ class CommandLineOptionsParserTest {
     void invalidTdbDir() {
         String[] args = stringArraysMerger(INVALID_TDB_DIR, VALID_ONTOLOGY, VALID_HPO_SINGLE, OUTPUT_FILE_NEW);
 
-        Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
+        Exception exception = Assertions.assertThrows(ParseException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals(TestData.NON_EXISTING_DIR.getName() + " is not a directory.", exception.getMessage());
     }
 
@@ -325,7 +324,7 @@ class CommandLineOptionsParserTest {
     void invalidTdbFile() {
         String[] args = stringArraysMerger(INVALID_TDB_FILE, VALID_ONTOLOGY, VALID_HPO_SINGLE, OUTPUT_FILE_NEW);
 
-        Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
+        Exception exception = Assertions.assertThrows(ParseException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals(TestData.NON_EXISTING_FILE.getName() + " is not a directory.", exception.getMessage());
     }
 
@@ -333,7 +332,7 @@ class CommandLineOptionsParserTest {
     void invalidOntologyFile() {
         String[] args = stringArraysMerger(VALID_TDB, INVALID_ONTOLOGY_FILE, HPO_ALGORITHM_CHILDREN, VALID_DISTANCE, VALID_HPO_SINGLE, OUTPUT_FILE_NEW);
 
-        Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
+        Exception exception = Assertions.assertThrows(ParseException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals(TestData.NON_EXISTING_FILE.getName() + " is not a readable file.", exception.getMessage());
     }
 
@@ -341,7 +340,7 @@ class CommandLineOptionsParserTest {
     void invalidOntologyDir() {
         String[] args = stringArraysMerger(VALID_TDB, INVALID_ONTOLOGY_DIR, HPO_ALGORITHM_CHILDREN, VALID_DISTANCE, VALID_HPO_SINGLE, OUTPUT_FILE_NEW);
 
-        Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
+        Exception exception = Assertions.assertThrows(ParseException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals(TestData.NON_EXISTING_DIR.getName() + " is not a readable file.", exception.getMessage());
     }
 

--- a/vibe-cli/src/test/java/org/molgenis/vibe/cli/io/options_digestion/CommandLineOptionsParserTest.java
+++ b/vibe-cli/src/test/java/org/molgenis/vibe/cli/io/options_digestion/CommandLineOptionsParserTest.java
@@ -21,7 +21,9 @@ import java.util.Set;
 
 class CommandLineOptionsParserTest {
     private final String[] HELP = new String[]{"-h"};
-    private final String[] VERBOSE = new String[]{"-v"};
+    private final String[] VERSION = new String[]{"-v"};
+    private final String[] DEBUG = new String[]{"-d"};
+    private final String[] FORCE_OVERWRITE = new String[]{"-f"};
     private final String[] SIMPLIFIED_OUT = new String[]{"-l"};
     private final String[] URIS_OUT = new String[]{"-u"};
 
@@ -53,12 +55,20 @@ class CommandLineOptionsParserTest {
             new Phenotype("hp:6543210")
     }));
 
-    private final String[] VALID_OUTPUT_FILE = new String[]{"-o", TestData.NON_EXISTING_FILE.getFullPathString()};
-    private final String[] INVALID_OUTPUT_FILE = new String[]{"-o", TestData.EXISTING_TSV.getFullPathString()};
+    private final String[] OUTPUT_FILE_NEW = new String[]{"-o", TestData.NON_EXISTING_FILE.getFullPathString()};
+    private final String[] OUTPUT_FILE_EXISTING = new String[]{"-o", TestData.EXISTING_TSV.getFullPathString()};
 
     @Test
     void helpMessage() throws IOException, ParseException {
         String[] args = stringArraysMerger(HELP);
+        VibeOptions vibeOptions = CommandLineOptionsParser.parse(args);
+
+        Assertions.assertEquals(RunMode.NONE, vibeOptions.getRunMode());
+    }
+
+    @Test
+    void versionMessage() throws IOException, ParseException {
+        String[] args = stringArraysMerger(VERSION);
         VibeOptions vibeOptions = CommandLineOptionsParser.parse(args);
 
         Assertions.assertEquals(RunMode.NONE, vibeOptions.getRunMode());
@@ -74,7 +84,7 @@ class CommandLineOptionsParserTest {
 
     @Test
     void validSingleHpoWithoutOntologyTraversalUsingDefaultOutputFile() throws IOException, ParseException {
-        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, VALID_HPO_SINGLE, VALID_OUTPUT_FILE);
+        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, VALID_HPO_SINGLE, OUTPUT_FILE_NEW);
         VibeOptions vibeOptions = CommandLineOptionsParser.parse(args);
 
         Assertions.assertAll(
@@ -82,47 +92,47 @@ class CommandLineOptionsParserTest {
                 () -> Assertions.assertEquals(VALID_HPO_SINGLE_SET, vibeOptions.getPhenotypes()),
                 () -> Assertions.assertEquals(false, vibeOptions.isVerbose()),
                 () -> Assertions.assertEquals(FileOutputWriter.class, vibeOptions.getOutputWriter().getClass()),
-                () -> Assertions.assertEquals(new FileOutputWriter(Paths.get(VALID_OUTPUT_FILE[1])).target(), vibeOptions.getOutputWriter().target()),
+                () -> Assertions.assertEquals(new FileOutputWriter(Paths.get(OUTPUT_FILE_NEW[1])).target(), vibeOptions.getOutputWriter().target()),
                 () -> Assertions.assertEquals(GenePrioritizedOutputFormatWriterFactory.REGULAR_ID, vibeOptions.getGenePrioritizedOutputFormatWriterFactory())
         );
     }
 
     @Test
     void validSingleHpoWithoutOntologyTraversalUsingDefaultOutputFileWithVerbose() throws IOException, ParseException {
-        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, VALID_HPO_SINGLE, VALID_OUTPUT_FILE, VERBOSE);
+        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, VALID_HPO_SINGLE, OUTPUT_FILE_NEW, DEBUG);
         VibeOptions vibeOptions = CommandLineOptionsParser.parse(args);
 
         Assertions.assertAll(
                 () -> Assertions.assertEquals(RunMode.GENES_FOR_PHENOTYPES, vibeOptions.getRunMode()),
                 () -> Assertions.assertEquals(true, vibeOptions.isVerbose()),
                 () -> Assertions.assertEquals(FileOutputWriter.class, vibeOptions.getOutputWriter().getClass()),
-                () -> Assertions.assertEquals(new FileOutputWriter(Paths.get(VALID_OUTPUT_FILE[1])).target(), vibeOptions.getOutputWriter().target()),
+                () -> Assertions.assertEquals(new FileOutputWriter(Paths.get(OUTPUT_FILE_NEW[1])).target(), vibeOptions.getOutputWriter().target()),
                 () -> Assertions.assertEquals(GenePrioritizedOutputFormatWriterFactory.REGULAR_ID, vibeOptions.getGenePrioritizedOutputFormatWriterFactory())
         );
     }
 
     @Test
     void validSingleHpoWithoutOntologyTraversalUsingUriOutputFile() throws IOException, ParseException {
-        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, VALID_HPO_SINGLE, VALID_OUTPUT_FILE, URIS_OUT);
+        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, VALID_HPO_SINGLE, OUTPUT_FILE_NEW, URIS_OUT);
         VibeOptions vibeOptions = CommandLineOptionsParser.parse(args);
 
         Assertions.assertAll(
                 () -> Assertions.assertEquals(RunMode.GENES_FOR_PHENOTYPES, vibeOptions.getRunMode()),
                 () -> Assertions.assertEquals(FileOutputWriter.class, vibeOptions.getOutputWriter().getClass()),
-                () -> Assertions.assertEquals(new FileOutputWriter(Paths.get(VALID_OUTPUT_FILE[1])).target(), vibeOptions.getOutputWriter().target()),
+                () -> Assertions.assertEquals(new FileOutputWriter(Paths.get(OUTPUT_FILE_NEW[1])).target(), vibeOptions.getOutputWriter().target()),
                 () -> Assertions.assertEquals(GenePrioritizedOutputFormatWriterFactory.REGULAR_URI, vibeOptions.getGenePrioritizedOutputFormatWriterFactory())
         );
     }
 
     @Test
     void validSingleHpoWithoutOntologyTraversalUsingSimplifiedOutputFile() throws IOException, ParseException {
-        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, VALID_HPO_SINGLE, VALID_OUTPUT_FILE, SIMPLIFIED_OUT);
+        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, VALID_HPO_SINGLE, OUTPUT_FILE_NEW, SIMPLIFIED_OUT);
         VibeOptions vibeOptions = CommandLineOptionsParser.parse(args);
 
         Assertions.assertAll(
                 () -> Assertions.assertEquals(RunMode.GENES_FOR_PHENOTYPES, vibeOptions.getRunMode()),
                 () -> Assertions.assertEquals(FileOutputWriter.class, vibeOptions.getOutputWriter().getClass()),
-                () -> Assertions.assertEquals(new FileOutputWriter(Paths.get(VALID_OUTPUT_FILE[1])).target(), vibeOptions.getOutputWriter().target()),
+                () -> Assertions.assertEquals(new FileOutputWriter(Paths.get(OUTPUT_FILE_NEW[1])).target(), vibeOptions.getOutputWriter().target()),
                 () -> Assertions.assertEquals(GenePrioritizedOutputFormatWriterFactory.SIMPLE, vibeOptions.getGenePrioritizedOutputFormatWriterFactory())
         );
     }
@@ -142,7 +152,7 @@ class CommandLineOptionsParserTest {
 
     @Test
     void validSingleHpoWithHpoAlgorithmChildren() throws IOException, ParseException {
-        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, HPO_ALGORITHM_CHILDREN, VALID_DISTANCE, VALID_HPO_SINGLE, VALID_OUTPUT_FILE);
+        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, HPO_ALGORITHM_CHILDREN, VALID_DISTANCE, VALID_HPO_SINGLE, OUTPUT_FILE_NEW);
         VibeOptions vibeOptions = CommandLineOptionsParser.parse(args);
 
         Assertions.assertAll(
@@ -153,7 +163,7 @@ class CommandLineOptionsParserTest {
 
     @Test
     void validSingleHpoWithHpoAlgorithmDistance() throws IOException, ParseException {
-        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, HPO_ALGORITHM_DISTANCE, VALID_DISTANCE, VALID_HPO_SINGLE, VALID_OUTPUT_FILE);
+        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, HPO_ALGORITHM_DISTANCE, VALID_DISTANCE, VALID_HPO_SINGLE, OUTPUT_FILE_NEW);
         VibeOptions vibeOptions = CommandLineOptionsParser.parse(args);
 
         Assertions.assertAll(
@@ -164,7 +174,7 @@ class CommandLineOptionsParserTest {
 
     @Test
     void validTwoHpos() throws IOException, ParseException {
-        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, VALID_HPO_MULTIPLE, VALID_OUTPUT_FILE);
+        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, VALID_HPO_MULTIPLE, OUTPUT_FILE_NEW);
         VibeOptions vibeOptions = CommandLineOptionsParser.parse(args);
 
         Assertions.assertEquals(VALID_HPO_MULTIPLE_SET, vibeOptions.getPhenotypes());
@@ -177,17 +187,31 @@ class CommandLineOptionsParserTest {
     }
 
     @Test
-    void validSingleHpoWithoutOntologyTraversalUsingInvalidOutputFile() {
-        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, VALID_HPO_SINGLE, INVALID_OUTPUT_FILE);
+    void validSingleHpoWithoutOntologyTraversalUsingExstingOutputFileWithOverwrite() throws IOException, ParseException {
+        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, VALID_HPO_SINGLE, OUTPUT_FILE_EXISTING, FORCE_OVERWRITE);
+        VibeOptions vibeOptions = CommandLineOptionsParser.parse(args);
+
+        Assertions.assertAll(
+                () -> Assertions.assertEquals(RunMode.GENES_FOR_PHENOTYPES, vibeOptions.getRunMode()),
+                () -> Assertions.assertEquals(VALID_HPO_SINGLE_SET, vibeOptions.getPhenotypes()),
+                () -> Assertions.assertEquals(false, vibeOptions.isVerbose()),
+                () -> Assertions.assertEquals(FileOutputWriter.class, vibeOptions.getOutputWriter().getClass()),
+                () -> Assertions.assertEquals(new FileOutputWriter(Paths.get(OUTPUT_FILE_EXISTING[1])).target(), vibeOptions.getOutputWriter().target()),
+                () -> Assertions.assertEquals(GenePrioritizedOutputFormatWriterFactory.REGULAR_ID, vibeOptions.getGenePrioritizedOutputFormatWriterFactory())
+        );
+    }
+
+    @Test
+    public void validSingleHpoWithoutOntologyTraversalUsingExstingOutputFileWithoutOverwrite() {
+        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, VALID_HPO_SINGLE, OUTPUT_FILE_EXISTING);
 
         Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals(TestData.EXISTING_TSV.getName() + " already exists.", exception.getMessage());
-
     }
 
     @Test
     void validSingleHpoWithInvalidHpoAlgorithm() {
-        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, HPO_ALGORITHM_INVALID, VALID_DISTANCE, VALID_HPO_SINGLE, VALID_OUTPUT_FILE);
+        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, HPO_ALGORITHM_INVALID, VALID_DISTANCE, VALID_HPO_SINGLE, OUTPUT_FILE_NEW);
 
         Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals(HPO_ALGORITHM_INVALID[1] + " is not a valid HPO retrieval algorithm.", exception.getMessage());
@@ -195,7 +219,7 @@ class CommandLineOptionsParserTest {
 
     @Test
     void validSingleHpoWithInvalidHpoAlgorithmDistanceNumber() {
-        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, HPO_ALGORITHM_CHILDREN, INVALID_DISTANCE_NUMBER, VALID_HPO_SINGLE, VALID_OUTPUT_FILE);
+        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, HPO_ALGORITHM_CHILDREN, INVALID_DISTANCE_NUMBER, VALID_HPO_SINGLE, OUTPUT_FILE_NEW);
 
         Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals(INVALID_DISTANCE_NUMBER[1] + " is not a valid HPO retrieval algorithm distance (must be a number >= 0).", exception.getMessage());
@@ -203,7 +227,7 @@ class CommandLineOptionsParserTest {
 
     @Test
     void validSingleHpoWithInvalidHpoAlgorithmDistanceString() {
-        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, HPO_ALGORITHM_CHILDREN, INVALID_DISTANCE_STRING, VALID_HPO_SINGLE, VALID_OUTPUT_FILE);
+        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, HPO_ALGORITHM_CHILDREN, INVALID_DISTANCE_STRING, VALID_HPO_SINGLE, OUTPUT_FILE_NEW);
 
         Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals(INVALID_DISTANCE_STRING[1] + " is not a valid HPO retrieval algorithm distance (must be a number >= 0).", exception.getMessage());
@@ -235,7 +259,7 @@ class CommandLineOptionsParserTest {
 
     @Test
     void noOntologyWithHpoAlgorithm() {
-        String[] args = stringArraysMerger(VALID_TDB, HPO_ALGORITHM_CHILDREN, VALID_HPO_SINGLE, VALID_OUTPUT_FILE);
+        String[] args = stringArraysMerger(VALID_TDB, HPO_ALGORITHM_CHILDREN, VALID_HPO_SINGLE, OUTPUT_FILE_NEW);
 
         Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals("Missing arguments: -w, -m", exception.getMessage());
@@ -243,7 +267,7 @@ class CommandLineOptionsParserTest {
 
     @Test
     void noOntologyWithHpoMaxDistance() {
-        String[] args = stringArraysMerger(VALID_TDB, VALID_DISTANCE, VALID_HPO_SINGLE, VALID_OUTPUT_FILE);
+        String[] args = stringArraysMerger(VALID_TDB, VALID_DISTANCE, VALID_HPO_SINGLE, OUTPUT_FILE_NEW);
 
         Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals("Missing arguments: -w, -n", exception.getMessage());
@@ -251,7 +275,7 @@ class CommandLineOptionsParserTest {
 
     @Test
     void withOntologyAndDistanceMissingHpoAlgorithm() {
-        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, VALID_DISTANCE, VALID_HPO_SINGLE, VALID_OUTPUT_FILE);
+        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, VALID_DISTANCE, VALID_HPO_SINGLE, OUTPUT_FILE_NEW);
 
         Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals("Missing arguments: -n", exception.getMessage());
@@ -259,7 +283,7 @@ class CommandLineOptionsParserTest {
 
     @Test
     void withOntologyAndAlgorithmMissingHpoMaxDistance() {
-        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, HPO_ALGORITHM_CHILDREN, VALID_HPO_SINGLE, VALID_OUTPUT_FILE);
+        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, HPO_ALGORITHM_CHILDREN, VALID_HPO_SINGLE, OUTPUT_FILE_NEW);
 
         Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals("Missing arguments: -m", exception.getMessage());
@@ -267,7 +291,7 @@ class CommandLineOptionsParserTest {
 
     @Test
     void withOntologyAlgorithmAndDistanceButNoOntologyFile() {
-        String[] args = stringArraysMerger(VALID_TDB, HPO_ALGORITHM_CHILDREN, VALID_DISTANCE, VALID_HPO_SINGLE, VALID_OUTPUT_FILE);
+        String[] args = stringArraysMerger(VALID_TDB, HPO_ALGORITHM_CHILDREN, VALID_DISTANCE, VALID_HPO_SINGLE, OUTPUT_FILE_NEW);
 
         Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals("Missing arguments: -w", exception.getMessage());
@@ -275,7 +299,7 @@ class CommandLineOptionsParserTest {
 
     @Test
     void missingPhenotype() {
-        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, VALID_OUTPUT_FILE);
+        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, OUTPUT_FILE_NEW);
 
         Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals("Missing arguments: -p", exception.getMessage());
@@ -283,7 +307,7 @@ class CommandLineOptionsParserTest {
 
     @Test
     void invalidPhenotype() {
-        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, INVALID_HPO, VALID_OUTPUT_FILE);
+        String[] args = stringArraysMerger(VALID_TDB, VALID_ONTOLOGY, INVALID_HPO, OUTPUT_FILE_NEW);
 
         Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals(INVALID_HPO[1] + " does not adhere the required format: ^(hp|HP):([0-9]{7})$", exception.getMessage());
@@ -291,7 +315,7 @@ class CommandLineOptionsParserTest {
 
     @Test
     void invalidTdbDir() {
-        String[] args = stringArraysMerger(INVALID_TDB_DIR, VALID_ONTOLOGY, VALID_HPO_SINGLE, VALID_OUTPUT_FILE);
+        String[] args = stringArraysMerger(INVALID_TDB_DIR, VALID_ONTOLOGY, VALID_HPO_SINGLE, OUTPUT_FILE_NEW);
 
         Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals(TestData.NON_EXISTING_DIR.getName() + " is not a directory.", exception.getMessage());
@@ -299,7 +323,7 @@ class CommandLineOptionsParserTest {
 
     @Test
     void invalidTdbFile() {
-        String[] args = stringArraysMerger(INVALID_TDB_FILE, VALID_ONTOLOGY, VALID_HPO_SINGLE, VALID_OUTPUT_FILE);
+        String[] args = stringArraysMerger(INVALID_TDB_FILE, VALID_ONTOLOGY, VALID_HPO_SINGLE, OUTPUT_FILE_NEW);
 
         Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals(TestData.NON_EXISTING_FILE.getName() + " is not a directory.", exception.getMessage());
@@ -307,7 +331,7 @@ class CommandLineOptionsParserTest {
 
     @Test
     void invalidOntologyFile() {
-        String[] args = stringArraysMerger(VALID_TDB, INVALID_ONTOLOGY_FILE, HPO_ALGORITHM_CHILDREN, VALID_DISTANCE, VALID_HPO_SINGLE, VALID_OUTPUT_FILE);
+        String[] args = stringArraysMerger(VALID_TDB, INVALID_ONTOLOGY_FILE, HPO_ALGORITHM_CHILDREN, VALID_DISTANCE, VALID_HPO_SINGLE, OUTPUT_FILE_NEW);
 
         Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals(TestData.NON_EXISTING_FILE.getName() + " is not a readable file.", exception.getMessage());
@@ -315,7 +339,7 @@ class CommandLineOptionsParserTest {
 
     @Test
     void invalidOntologyDir() {
-        String[] args = stringArraysMerger(VALID_TDB, INVALID_ONTOLOGY_DIR, HPO_ALGORITHM_CHILDREN, VALID_DISTANCE, VALID_HPO_SINGLE, VALID_OUTPUT_FILE);
+        String[] args = stringArraysMerger(VALID_TDB, INVALID_ONTOLOGY_DIR, HPO_ALGORITHM_CHILDREN, VALID_DISTANCE, VALID_HPO_SINGLE, OUTPUT_FILE_NEW);
 
         Exception exception = Assertions.assertThrows(IOException.class, () -> CommandLineOptionsParser.parse(args) );
         Assertions.assertEquals(TestData.NON_EXISTING_DIR.getName() + " is not a readable file.", exception.getMessage());

--- a/vibe-cli/src/test/java/org/molgenis/vibe/cli/io/options_digestion/VibeOptionsTest.java
+++ b/vibe-cli/src/test/java/org/molgenis/vibe/cli/io/options_digestion/VibeOptionsTest.java
@@ -38,10 +38,17 @@ class VibeOptionsTest {
     }
 
     @Test
-    void validRunModeNone() {
-        vibeOptions.setRunMode(RunMode.NONE);
+    void validRunModeHelp() {
+        vibeOptions.setRunMode(RunMode.HELP);
 
-        vibeOptions.validate();
+        Assertions.assertTrue(vibeOptions.validate());
+    }
+
+    @Test
+    void validRunModeVersion() {
+        vibeOptions.setRunMode(RunMode.VERSION);
+
+        Assertions.assertTrue(vibeOptions.validate());
     }
 
     @Test

--- a/vibe-cli/src/test/java/org/molgenis/vibe/cli/io/options_digestion/VibeOptionsTest.java
+++ b/vibe-cli/src/test/java/org/molgenis/vibe/cli/io/options_digestion/VibeOptionsTest.java
@@ -196,6 +196,4 @@ class VibeOptionsTest {
     void invalidHpoDir() {
         Assertions.assertThrows(IOException.class, () -> vibeOptions.setHpoOntology(INVALID_ONTOLOGY_DIR) );
     }
-
-
 }

--- a/vibe-cli/src/test/java/org/molgenis/vibe/cli/properties/VibePropertiesLoaderTest.java
+++ b/vibe-cli/src/test/java/org/molgenis/vibe/cli/properties/VibePropertiesLoaderTest.java
@@ -9,7 +9,7 @@ import java.io.IOException;
  * Note that {@link VibePropertiesLoader#loadProperties()} only needs to be run once app-wide, so any pre-loading tests
  * could cause issues if other tests elsewhere would also load the properties file due to needing values from it.
  */
-public class VibePropertiesLoaderTest {
+class VibePropertiesLoaderTest {
     @Test
     void testIfVibePropertiesSetAfterLoading() throws IOException {
         VibePropertiesLoader.loadProperties();

--- a/vibe-cli/src/test/java/org/molgenis/vibe/cli/properties/VibePropertiesLoaderTest.java
+++ b/vibe-cli/src/test/java/org/molgenis/vibe/cli/properties/VibePropertiesLoaderTest.java
@@ -1,0 +1,22 @@
+package org.molgenis.vibe.cli.properties;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/**
+ * Note that {@link VibePropertiesLoader#loadProperties()} only needs to be run once app-wide, so any pre-loading tests
+ * could cause issues if other tests elsewhere would also load the properties file due to needing values from it.
+ */
+public class VibePropertiesLoaderTest {
+    @Test
+    void testIfVibePropertiesSetAfterLoading() throws IOException {
+        VibePropertiesLoader.loadProperties();
+
+        Assertions.assertAll(
+                () -> Assertions.assertNotNull(VibeProperties.APP_NAME.getValue()),
+                () -> Assertions.assertNotNull(VibeProperties.APP_VERSION.getValue())
+        );
+    }
+}


### PR DESCRIPTION
- `-v`, `-d` & `-f` now adjusted to defined internal standard.
- Adjustments `pom.xml` in regards to creating the überjar.
- Now uses a `application.properties` file to store and retrieve certain information from (currently: application name & version number).
- Added warning suppression for SonarCloud for switch without break.
- Split up the validation of `VibeOptions` into several private methods.