### PR TITLE
Hashcode bug fix

### DIFF
--- a/vibe-core/src/main/java/org/molgenis/vibe/core/formats/BiologicalEntityCollection.java
+++ b/vibe-core/src/main/java/org/molgenis/vibe/core/formats/BiologicalEntityCollection.java
@@ -258,6 +258,6 @@ public abstract class BiologicalEntityCollection<T1 extends BiologicalEntity, T2
 
     @Override
     public int hashCode() {
-        return Objects.hash(combinationsMap);
+        return Objects.hash(combinationsMap.keySet());
     }
 }

--- a/vibe-core/src/main/java/org/molgenis/vibe/core/formats/BiologicalEntityCollection.java
+++ b/vibe-core/src/main/java/org/molgenis/vibe/core/formats/BiologicalEntityCollection.java
@@ -71,10 +71,10 @@ public abstract class BiologicalEntityCollection<T1 extends BiologicalEntity, T2
         return ((combinationsByT2.get(t2) == null) ? null : Collections.unmodifiableSet(combinationsByT2.get(t2)));
     }
 
-    public BiologicalEntityCollection() {
+    protected BiologicalEntityCollection() {
     }
 
-    public BiologicalEntityCollection(Collection<? extends T3> combinations) {
+    protected BiologicalEntityCollection(Collection<? extends T3> combinations) {
         addAll(combinations);
     }
 

--- a/vibe-core/src/test/java/org/molgenis/vibe/core/formats/BiologicalEntityCollectionTest.java
+++ b/vibe-core/src/test/java/org/molgenis/vibe/core/formats/BiologicalEntityCollectionTest.java
@@ -345,4 +345,16 @@ class BiologicalEntityCollectionTest {
         collection.remove(combinations[3]);
         Assertions.assertFalse(collection.contains(combinations[3]));
     }
+
+    @Test
+    void hashNotEqual() {
+        BiologicalEntityCollectionImpl collection1 = new BiologicalEntityCollectionImpl();
+        collection1.add(combinations[0]);
+        collection1.add(combinations[1]);
+
+        BiologicalEntityCollectionImpl collection2 = new BiologicalEntityCollectionImpl();
+        collection2.add(combinations[2]);
+
+        Assertions.assertNotEquals(collection1.hashCode(), collection2.hashCode());
+    }
 }

--- a/vibe-core/src/test/java/org/molgenis/vibe/core/formats/BiologicalEntityCollectionTest.java
+++ b/vibe-core/src/test/java/org/molgenis/vibe/core/formats/BiologicalEntityCollectionTest.java
@@ -347,13 +347,45 @@ class BiologicalEntityCollectionTest {
     }
 
     @Test
-    void hashNotEqual() {
+    void hashDifferentSize() {
         BiologicalEntityCollectionImpl collection1 = new BiologicalEntityCollectionImpl();
         collection1.add(combinations[0]);
         collection1.add(combinations[1]);
 
         BiologicalEntityCollectionImpl collection2 = new BiologicalEntityCollectionImpl();
         collection2.add(combinations[2]);
+
+        Assertions.assertNotEquals(collection1.hashCode(), collection2.hashCode());
+    }
+
+    @Test
+    void hashSameSizeDifferentContent() {
+        BiologicalEntityCollectionImpl collection1 = new BiologicalEntityCollectionImpl();
+        collection1.add(combinations[0]);
+
+        BiologicalEntityCollectionImpl collection2 = new BiologicalEntityCollectionImpl();
+        collection2.add(combinations[2]);
+
+        Assertions.assertNotEquals(collection1.hashCode(), collection2.hashCode());
+    }
+
+    @Test
+    void hashSameSizeSameContent() {
+        BiologicalEntityCollectionImpl collection1 = new BiologicalEntityCollectionImpl();
+        collection1.add(combinations[1]);
+
+        BiologicalEntityCollectionImpl collection2 = new BiologicalEntityCollectionImpl();
+        collection2.add(combinations[1]);
+
+        Assertions.assertEquals(collection1.hashCode(), collection2.hashCode());
+    }
+
+    @Test
+    void hashEmptyVersusFilled() {
+        BiologicalEntityCollectionImpl collection1 = new BiologicalEntityCollectionImpl();
+
+        BiologicalEntityCollectionImpl collection2 = new BiologicalEntityCollectionImpl();
+        collection2.add(combinations[1]);
 
         Assertions.assertNotEquals(collection1.hashCode(), collection2.hashCode());
     }


### PR DESCRIPTION
Fixed a bug causing hashcodes to malfunction for `BiologicalEntityCollection` (note that these currently are not compared as a single `BiologicalEntityCollection` currently functions as the final output from a query which is then further processed).