### PR TITLE
Fix/sonarcloud coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -446,6 +446,12 @@
                 <version>${mockito.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <rdfhdt.version>2.1.2</rdfhdt.version>
         <commons-cli.version>1.4</commons-cli.version>
         <junit-jupiter.version>5.6.0</junit-jupiter.version>
-        <mockito.version>1.10.19</mockito.version>
+        <mockito.version>3.7.7</mockito.version>
     </properties>
 
     <distributionManagement>
@@ -442,7 +442,7 @@
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
-                <artifactId>mockito-all</artifactId>
+                <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
                 <scope>test</scope>
             </dependency>

--- a/vibe-cli/pom.xml
+++ b/vibe-cli/pom.xml
@@ -138,5 +138,10 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/vibe-cli/pom.xml
+++ b/vibe-cli/pom.xml
@@ -136,7 +136,7 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/vibe-cli/src/test/java/org/molgenis/vibe/cli/RunModeIT.java
+++ b/vibe-cli/src/test/java/org/molgenis/vibe/cli/RunModeIT.java
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.when;
  * will not be shown correctly.
  */
 @ExtendWith(MockitoExtension.class)
-public class RunModeIT {
+class RunModeIT {
     @Mock private VibeOptions mockedVibeOptions;
 
     // Define stdout information.

--- a/vibe-cli/src/test/java/org/molgenis/vibe/cli/RunModeIT.java
+++ b/vibe-cli/src/test/java/org/molgenis/vibe/cli/RunModeIT.java
@@ -1,0 +1,74 @@
+package org.molgenis.vibe.cli;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.molgenis.vibe.cli.io.options_digestion.VibeOptions;
+import org.molgenis.vibe.cli.io.output.format.gene_prioritized.GenePrioritizedOutputFormatWriterFactory;
+import org.molgenis.vibe.cli.io.output.target.StdoutOutputWriter;
+import org.molgenis.vibe.core.formats.Phenotype;
+import org.molgenis.vibe.core.io.input.ModelReaderFactory;
+import org.molgenis.vibe.core.io.input.VibeDatabase;
+import org.molgenis.vibe.core.ontology_processing.PhenotypesRetrieverFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class RunModeIT {
+    @Mock private VibeOptions mockedVibeOptions;
+
+    @Test
+    void testIfHelpWorks() throws IOException {
+        // Only tests if everything works as a whole. Actual data processing validation is done in their own tests.
+        Assertions.assertDoesNotThrow(() -> RunMode.HELP.run(mockedVibeOptions));
+    }
+
+    @Test
+    void testIfVersionWorks() throws IOException {
+        // Only tests if everything works as a whole. Actual data processing validation is done in their own tests.
+        Assertions.assertDoesNotThrow(() -> RunMode.VERSION.run(mockedVibeOptions));
+    }
+
+    @Test
+    void testIfGenesForPhenotypesWorks() throws IOException {
+        when(mockedVibeOptions.getPhenotypes())
+                .thenReturn(new HashSet<>(Arrays.asList(new Phenotype("hp:0008438"))));
+
+        when(mockedVibeOptions.getVibeDatabase())
+                .thenReturn(new VibeDatabase(TestData.HDT.getFullPath(), ModelReaderFactory.HDT));
+
+        when(mockedVibeOptions.getGenePrioritizedOutputFormatWriterFactory())
+                .thenReturn(GenePrioritizedOutputFormatWriterFactory.SIMPLE);
+        when(mockedVibeOptions.getOutputWriter()).thenReturn(new StdoutOutputWriter());
+
+        // Only tests if everything works as a whole. Actual data processing validation is done in their own tests.
+        Assertions.assertDoesNotThrow(() -> RunMode.GENES_FOR_PHENOTYPES.run(mockedVibeOptions));
+    }
+
+    @Test
+    void testIfGenesForPhenotypesWithAssociatedPhenotypesWorks() throws IOException {
+        when(mockedVibeOptions.getPhenotypes())
+                .thenReturn(new HashSet<>(Arrays.asList(new Phenotype("hp:0008438"))));
+        when(mockedVibeOptions.getHpoOntology()).thenReturn(TestData.HPO_OWL.getFullPath());
+        when(mockedVibeOptions.getPhenotypesRetrieverFactory()).thenReturn(PhenotypesRetrieverFactory.CHILDREN);
+        when(mockedVibeOptions.getOntologyMaxDistance()).thenReturn(0);
+
+        when(mockedVibeOptions.getVibeDatabase())
+                .thenReturn(new VibeDatabase(TestData.HDT.getFullPath(), ModelReaderFactory.HDT));
+
+        when(mockedVibeOptions.getGenePrioritizedOutputFormatWriterFactory())
+                .thenReturn(GenePrioritizedOutputFormatWriterFactory.SIMPLE);
+        when(mockedVibeOptions.getOutputWriter()).thenReturn(new StdoutOutputWriter());
+
+        // Only tests if everything works as a whole. Actual data processing validation is done in their own tests.
+        Assertions.assertDoesNotThrow(
+                () -> RunMode.GENES_FOR_PHENOTYPES_WITH_ASSOCIATED_PHENOTYPES.run(mockedVibeOptions)
+        );
+    }
+}

--- a/vibe-cli/src/test/java/org/molgenis/vibe/cli/RunModeIT.java
+++ b/vibe-cli/src/test/java/org/molgenis/vibe/cli/RunModeIT.java
@@ -1,6 +1,8 @@
 package org.molgenis.vibe.cli;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -13,30 +15,56 @@ import org.molgenis.vibe.core.io.input.ModelReaderFactory;
 import org.molgenis.vibe.core.io.input.VibeDatabase;
 import org.molgenis.vibe.core.ontology_processing.PhenotypesRetrieverFactory;
 
-import java.io.IOException;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.util.Arrays;
 import java.util.HashSet;
 
 import static org.mockito.Mockito.when;
 
+/**
+ * Tests to ensure the logic that calls the different processes does not cause any errors. Note that
+ * {@link org.molgenis.vibe.cli.properties.VibeProperties} is not loaded, therefore fields such as the version number
+ * will not be shown correctly.
+ */
 @ExtendWith(MockitoExtension.class)
 public class RunModeIT {
     @Mock private VibeOptions mockedVibeOptions;
 
+    // Define stdout information.
+    private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+    private final PrintStream originalOut = System.out;
+
+    /**
+     * Custom "stdout".
+     */
+    @BeforeEach
+    void beforeEach() {
+        System.setOut(new PrintStream(outContent));
+    }
+
+    /**
+     * Resets stdout.
+     */
+    @AfterEach
+    void afterEach() {
+        System.setOut(originalOut);
+    }
+
     @Test
-    void testIfHelpWorks() throws IOException {
-        // Only tests if everything works as a whole. Actual data processing validation is done in their own tests.
+    void testIfHelpWorks() {
+        // Simply tests if calling the help message will not generate any errors.
         Assertions.assertDoesNotThrow(() -> RunMode.HELP.run(mockedVibeOptions));
     }
 
     @Test
-    void testIfVersionWorks() throws IOException {
-        // Only tests if everything works as a whole. Actual data processing validation is done in their own tests.
+    void testIfVersionWorks() {
+        // Simply tests if showing the version number will not generate any errors.
         Assertions.assertDoesNotThrow(() -> RunMode.VERSION.run(mockedVibeOptions));
     }
 
     @Test
-    void testIfGenesForPhenotypesWorks() throws IOException {
+    void testIfGenesForPhenotypesWorks() throws Exception {
         when(mockedVibeOptions.getPhenotypes())
                 .thenReturn(new HashSet<>(Arrays.asList(new Phenotype("hp:0008438"))));
 
@@ -47,12 +75,14 @@ public class RunModeIT {
                 .thenReturn(GenePrioritizedOutputFormatWriterFactory.SIMPLE);
         when(mockedVibeOptions.getOutputWriter()).thenReturn(new StdoutOutputWriter());
 
-        // Only tests if everything works as a whole. Actual data processing validation is done in their own tests.
-        Assertions.assertDoesNotThrow(() -> RunMode.GENES_FOR_PHENOTYPES.run(mockedVibeOptions));
+        // Main goal is to ensure no errors are thrown, but output validation purely for gene order is present as well.
+        // Based on: GeneDiseaseCollectionRetrievalRunnerIT if sorted by GenePrioritizedOutputFormatWriterFactory.SIMPLE
+        RunMode.GENES_FOR_PHENOTYPES.run(mockedVibeOptions);
+        Assertions.assertEquals("29123,56172,2697,286,479", outContent.toString());
     }
 
     @Test
-    void testIfGenesForPhenotypesWithAssociatedPhenotypesWorks() throws IOException {
+    void testIfGenesForPhenotypesWithAssociatedPhenotypesWorks() throws Exception {
         when(mockedVibeOptions.getPhenotypes())
                 .thenReturn(new HashSet<>(Arrays.asList(new Phenotype("hp:0008438"))));
         when(mockedVibeOptions.getHpoOntology()).thenReturn(TestData.HPO_OWL.getFullPath());
@@ -66,9 +96,11 @@ public class RunModeIT {
                 .thenReturn(GenePrioritizedOutputFormatWriterFactory.SIMPLE);
         when(mockedVibeOptions.getOutputWriter()).thenReturn(new StdoutOutputWriter());
 
-        // Only tests if everything works as a whole. Actual data processing validation is done in their own tests.
-        Assertions.assertDoesNotThrow(
-                () -> RunMode.GENES_FOR_PHENOTYPES_WITH_ASSOCIATED_PHENOTYPES.run(mockedVibeOptions)
-        );
+        // Main goal is to ensure no errors are thrown, but output validation purely for gene order is present as well.
+        // Note that while ontology retrieval is done, due to distance 0 the output is the same. This might change when
+        // https://github.com/molgenis/vibe/issues/25 gets implemented.
+        // Based on: GeneDiseaseCollectionRetrievalRunnerIT if sorted by GenePrioritizedOutputFormatWriterFactory.SIMPLE
+        RunMode.GENES_FOR_PHENOTYPES_WITH_ASSOCIATED_PHENOTYPES.run(mockedVibeOptions);
+        Assertions.assertEquals("29123,56172,2697,286,479", outContent.toString());
     }
 }

--- a/vibe-core/pom.xml
+++ b/vibe-core/pom.xml
@@ -135,7 +135,7 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
 
         <dependency>

--- a/vibe-core/pom.xml
+++ b/vibe-core/pom.xml
@@ -139,6 +139,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.8.6</version>


### PR DESCRIPTION
Added some basic tests for `RunMode` that show no errors are thrown by the logic that runs the different processes in order. Some simplistic output check is done as well, though not in much detail as for that there are dedicated unit-tests that validate the individual processes by themselves.