### PR TITLE
Fix/invalid hgnc hotfix

### DIFF
--- a/database/sparql_queries/other/README.md
+++ b/database/sparql_queries/other/README.md
@@ -21,7 +21,12 @@ tdbquery --time --loc=/path/to/initial/TDB --query=/path/to/vibe/database/sparql
 **NOTE:** As some of the GDAs within DisGeNET were inferred from the VDAs stored in the dataset, duplicate results might be present. See also "Inferred Data" on http://disgenet.org/dbinfo.
 
 
+## For optimized HDT
+### All stored gene IDs & their symbol
 
+```bash
+hdtsparql.sh vibe-<version>-hdt/vibe-<version>.hdt "$(cat /path/to/database/sparql_queries/other/optimized_database/gene_symbols.rq)" 1> output.tsv
+```
 
 
 

--- a/database/sparql_queries/other/optimized_database/all_gene_ids_and_symbols.rq
+++ b/database/sparql_queries/other/optimized_database/all_gene_ids_and_symbols.rq
@@ -1,0 +1,10 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX sio: <http://semanticscience.org/resource/>
+PREFIX ncit: <http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#>
+
+SELECT ?gene ?symbol
+WHERE {
+    ?gene rdf:type ncit:C16612 ;
+    sio:SIO_000205 ?symbol .
+}
+ORDER BY ?gene

--- a/vibe-cli/src/main/java/org/molgenis/vibe/cli/io/output/format/gene_prioritized/ResultsPerGeneSeparatedValuesOutputFormatWriter.java
+++ b/vibe-cli/src/main/java/org/molgenis/vibe/cli/io/output/format/gene_prioritized/ResultsPerGeneSeparatedValuesOutputFormatWriter.java
@@ -76,7 +76,7 @@ public abstract class ResultsPerGeneSeparatedValuesOutputFormatWriter extends Pr
 
     public void generateOutput() throws IOException {
         // Writes header.
-        getOutputWriter().writeHeader("gene (NCBI)" + primarySeparator + "gene symbol (HGNC)" + primarySeparator + "highest GDA score" + primarySeparator + "diseases (UMLS) with sources per disease");
+        getOutputWriter().writeHeader("gene (NCBI)" + primarySeparator + "gene symbol (derived from NCBI)" + primarySeparator + "highest GDA score" + primarySeparator + "diseases (UMLS) with sources per disease");
         getOutputWriter().writeNewLine();
 
         // Goes through all ordered genes.

--- a/vibe-cli/src/test/java/org/molgenis/vibe/cli/io/output/format/gene_prioritized/GenePrioritizedOutputFormatWriterFactoryTest.java
+++ b/vibe-cli/src/test/java/org/molgenis/vibe/cli/io/output/format/gene_prioritized/GenePrioritizedOutputFormatWriterFactoryTest.java
@@ -15,6 +15,10 @@ import java.util.HashSet;
 import java.util.List;
 
 class GenePrioritizedOutputFormatWriterFactoryTest {
+    // Header for non-simple output format.
+    private static final String EXPECTED_HEADER = "gene (NCBI)\tgene symbol (derived from NCBI)\thighest GDA score\tdiseases (UMLS) with sources per disease";
+
+
     private static final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
     private static final PrintStream originalOut = System.out;
 
@@ -95,7 +99,7 @@ class GenePrioritizedOutputFormatWriterFactoryTest {
     void testDefaultWithId() throws IOException {
         OutputFormatWriter formatWriter = GenePrioritizedOutputFormatWriterFactory.REGULAR_ID.create(writer, collection, priority);
         formatWriter.run();
-        String expectedOutput = "gene (NCBI)\tgene symbol (HGNC)\thighest GDA score\tdiseases (UMLS) with sources per disease" + System.lineSeparator() +
+        String expectedOutput = EXPECTED_HEADER + System.lineSeparator() +
                 "29123\tANKRD11\t0.8\tC0220687 (0.8):26633545,23494856|C1835764 (0.1)" + System.lineSeparator() +
                 "2697\tGJA1\t0.31\tC0265292 (0.31):23951358" + System.lineSeparator();
         Assertions.assertEquals(expectedOutput, outContent.toString());
@@ -105,7 +109,7 @@ class GenePrioritizedOutputFormatWriterFactoryTest {
     void testDefaultWithUri() throws IOException {
         OutputFormatWriter formatWriter = GenePrioritizedOutputFormatWriterFactory.REGULAR_URI.create(writer, collection, priority);
         formatWriter.run();
-        String expectedOutput = "gene (NCBI)\tgene symbol (HGNC)\thighest GDA score\tdiseases (UMLS) with sources per disease" + System.lineSeparator() +
+        String expectedOutput = EXPECTED_HEADER + System.lineSeparator() +
                 "http://identifiers.org/ncbigene/29123\thttp://identifiers.org/hgnc.symbol/ANKRD11\t0.8\thttp://linkedlifedata.com/resource/umls/id/C0220687 (0.8):http://identifiers.org/pubmed/26633545,http://identifiers.org/pubmed/23494856|http://linkedlifedata.com/resource/umls/id/C1835764 (0.1)" + System.lineSeparator() +
                 "http://identifiers.org/ncbigene/2697\thttp://identifiers.org/hgnc.symbol/GJA1\t0.31\thttp://linkedlifedata.com/resource/umls/id/C0265292 (0.31):http://identifiers.org/pubmed/23951358" + System.lineSeparator();
         Assertions.assertEquals(expectedOutput, outContent.toString());
@@ -123,7 +127,7 @@ class GenePrioritizedOutputFormatWriterFactoryTest {
     void testDefaultWithIdEmpty() throws IOException {
         OutputFormatWriter formatWriter = GenePrioritizedOutputFormatWriterFactory.REGULAR_ID.create(writer, emptyCollection, emptyPriority);
         formatWriter.run();
-        String expectedOutput = "gene (NCBI)\tgene symbol (HGNC)\thighest GDA score\tdiseases (UMLS) with sources per disease" + System.lineSeparator();
+        String expectedOutput = EXPECTED_HEADER + System.lineSeparator();
         Assertions.assertEquals(expectedOutput, outContent.toString());
     }
 
@@ -131,7 +135,7 @@ class GenePrioritizedOutputFormatWriterFactoryTest {
     void testDefaultWithUriEmpty() throws IOException {
         OutputFormatWriter formatWriter = GenePrioritizedOutputFormatWriterFactory.REGULAR_URI.create(writer, emptyCollection, emptyPriority);
         formatWriter.run();
-        String expectedOutput = "gene (NCBI)\tgene symbol (HGNC)\thighest GDA score\tdiseases (UMLS) with sources per disease" + System.lineSeparator();
+        String expectedOutput = EXPECTED_HEADER + System.lineSeparator();
         Assertions.assertEquals(expectedOutput, outContent.toString());
     }
 
@@ -147,7 +151,7 @@ class GenePrioritizedOutputFormatWriterFactoryTest {
     void testDefaultWithIdSingleResult() throws IOException {
         OutputFormatWriter formatWriter = GenePrioritizedOutputFormatWriterFactory.REGULAR_ID.create(writer, collectionSingleResult, prioritySingleResult);
         formatWriter.run();
-        String expectedOutput = "gene (NCBI)\tgene symbol (HGNC)\thighest GDA score\tdiseases (UMLS) with sources per disease" + System.lineSeparator() +
+        String expectedOutput = EXPECTED_HEADER + System.lineSeparator() +
                 "29123\tANKRD11\t0.8\tC0220687 (0.8):26633545,23494856|C1835764 (0.1)" + System.lineSeparator();
         Assertions.assertEquals(expectedOutput, outContent.toString());
     }
@@ -156,7 +160,7 @@ class GenePrioritizedOutputFormatWriterFactoryTest {
     void testDefaultWithUriSingleResult() throws IOException {
         OutputFormatWriter formatWriter = GenePrioritizedOutputFormatWriterFactory.REGULAR_URI.create(writer, collectionSingleResult, prioritySingleResult);
         formatWriter.run();
-        String expectedOutput = "gene (NCBI)\tgene symbol (HGNC)\thighest GDA score\tdiseases (UMLS) with sources per disease" + System.lineSeparator() +
+        String expectedOutput = EXPECTED_HEADER + System.lineSeparator() +
                 "http://identifiers.org/ncbigene/29123\thttp://identifiers.org/hgnc.symbol/ANKRD11\t0.8\thttp://linkedlifedata.com/resource/umls/id/C0220687 (0.8):http://identifiers.org/pubmed/26633545,http://identifiers.org/pubmed/23494856|http://linkedlifedata.com/resource/umls/id/C1835764 (0.1)" + System.lineSeparator();
         Assertions.assertEquals(expectedOutput, outContent.toString());
     }

--- a/vibe-core/src/main/java/org/molgenis/vibe/core/formats/GeneSymbol.java
+++ b/vibe-core/src/main/java/org/molgenis/vibe/core/formats/GeneSymbol.java
@@ -4,7 +4,10 @@ import java.net.URI;
 
 public class GeneSymbol extends Entity {
     public static final String ID_PREFIX = "hgnc";
-    private static final String ID_REGEX = "^(hgnc|HGNC):([a-zA-Z0-9#@/._-]+)$";
+    // This class should be redesigned when a new DisGeNET release is being implemented
+    // after they fixed non-HGNC symbols being marked as HGNC symbols.
+    // See: https://github.com/molgenis/vibe/issues/82
+    private static final String ID_REGEX = "^(hgnc|HGNC):([a-zA-Z0-9#@/.'_+-]+)$";
     private static final int REGEX_ID_GROUP = 2;
     private static final String URI_PREFIX = "http://identifiers.org/hgnc.symbol/";
 

--- a/vibe-core/src/test/java/org/molgenis/vibe/core/GeneDiseaseCollectionRetrievalRunnerIT.java
+++ b/vibe-core/src/test/java/org/molgenis/vibe/core/GeneDiseaseCollectionRetrievalRunnerIT.java
@@ -3,6 +3,7 @@ package org.molgenis.vibe.core;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.molgenis.vibe.core.exceptions.InvalidStringFormatException;
 import org.molgenis.vibe.core.formats.*;
 import org.molgenis.vibe.core.io.input.ModelReaderFactory;
 import org.molgenis.vibe.core.io.input.VibeDatabase;
@@ -139,5 +140,19 @@ class GeneDiseaseCollectionRetrievalRunnerIT {
             () -> Assertions.assertEquals(expectedCollection, actualCollection),
             () -> Assertions.assertTrue(expectedCollection.allFieldsEquals(actualCollection))
         );
+    }
+
+    /**
+     * Based on DisGeNET v7.0.0. A future release of DisGeNET should make this test obsolete.
+     * @throws IOException
+     */
+    @Test
+    void testPhenotypeReturningInvalidHgncSymbol() throws IOException {
+        runner = new GeneDiseaseCollectionRetrievalRunner(
+                new VibeDatabase(TestData.HDT.getFullPath(), ModelReaderFactory.HDT),
+                new HashSet<>(Arrays.asList(new Phenotype("hp:0002664")))
+        );
+
+        Assertions.assertDoesNotThrow(() -> runner.call(), String.valueOf(InvalidStringFormatException.class));
     }
 }

--- a/vibe-core/src/test/java/org/molgenis/vibe/core/formats/GeneSymbolTest.java
+++ b/vibe-core/src/test/java/org/molgenis/vibe/core/formats/GeneSymbolTest.java
@@ -195,4 +195,10 @@ class GeneSymbolTest {
                 () -> Assertions.assertEquals(URI.create("http://identifiers.org/hgnc.symbol/GS1-600G8.3"), symbol.getUri())
         );
     }
+
+    @Test
+    void useInvalidHgncSymbolThatShouldBeAcceptedDueToDisgenetBug() {
+        Assertions.assertDoesNotThrow(() -> new GeneSymbol(URI.create("http://identifiers.org/hgnc.symbol/MCS+9.7")),
+                String.valueOf(InvalidStringFormatException.class));
+    }
 }


### PR DESCRIPTION
### Changes
- Hotfix for #82.

### Important notes
Future releases of DisGeNET will probably require additional changes as this fix simply accepts non-HGNC symbols where HGNC symbols are accepted (but still uses the invalid IRI's generated by DisGeNET). See for more information the thread in #82.

### Checklists
Please update the checklists when steps are completed.

##### Before merge
- [ ] Functionality works & meets specs
- [ ] Code reviewed
- [ ] Documentation was updated

##### After merge
- [ ] Added feature/fix to draft release notes
- [ ] Removed merged branches